### PR TITLE
Store malware findings individually

### DIFF
--- a/malware/__main__.py
+++ b/malware/__main__.py
@@ -1,5 +1,7 @@
 import argparse
 import atexit
+import collections.abc
+import datetime
 import logging
 import os
 import signal
@@ -11,11 +13,10 @@ import boto3
 
 import ccc.oci
 import ci.log
-import clamav.cnudie
-import clamav.model
 import cnudie.iter
 import cnudie.retrieve
 import delivery.client
+import dso.model
 import gci.componentmodel as cm
 import model.aws
 import oci.client
@@ -134,12 +135,9 @@ def scan_resource(
     resource_node: cnudie.iter.ResourceNode,
     oci_client: oci.client.Client,
     s3_client: 'boto3.resources.factory.s3.ServiceResource | None',
-) -> clamav.model.ClamAVResourceScanResult:
-    component = resource_node.component
+) -> collections.abc.Generator[dso.model.ClamAVMalwareFinding, None, None]:
     resource = resource_node.resource
     resource: cm.Resource
-
-    resource_name = f'{component.name}/{resource.name}'
 
     if isinstance(resource.access, cm.OciAccess):
         results = malware.scan.scan_oci_image(
@@ -165,17 +163,37 @@ def scan_resource(
     else:
         raise NotImplementedError(type(resource.access))
 
-    scan_result = malware.scan.aggregate_scan_result(
-        resource=resource,
-        results=results,
-        name=resource_name,
-        clamav_version_info=malware.clamav.clamscan_version(),
+    return results
+
+
+def _iter_clamav_malware_findings(
+    findings: collections.abc.Iterable[dso.model.ClamAVMalwareFinding],
+    resource_node: cnudie.iter.ResourceNode,
+    datasource: str = dso.model.Datasource.CLAMAV,
+    datatype: str = dso.model.Datatype.MALWARE_FINDING,
+) -> collections.abc.Generator[dso.model.ArtefactMetadata, None, None]:
+    discovery_date = datetime.date.today()
+    now = datetime.datetime.now()
+
+    artefact_ref = dso.model.component_artefact_id_from_ocm(
+        component=resource_node.component,
+        artefact=resource_node.artefact,
     )
 
-    return clamav.model.ClamAVResourceScanResult(
-        scan_result=scan_result,
-        scanned_element=resource_node,
+    meta = dso.model.Metadata(
+        datasource=datasource,
+        type=datatype,
+        creation_date=now,
+        last_update=now,
     )
+
+    for finding in findings:
+        yield dso.model.ArtefactMetadata(
+            artefact=artefact_ref,
+            meta=meta,
+            data=finding,
+            discovery_date=discovery_date
+        )
 
 
 def scan_and_upload(
@@ -201,10 +219,18 @@ def scan_and_upload(
         s3_client=s3_client,
     )
 
-    logger.info('scan completed, uploading to delivery-service')
+    scan_info = dso.model.artefact_scan_info(
+        artefact_node=resource_node,
+        datasource=dso.model.Datasource.CLAMAV,
+    )
 
     delivery_client.update_metadata(
-        data=[clamav.cnudie.resource_scan_result_to_artefact_metadata(result)],
+        data=list(
+            _iter_clamav_malware_findings(
+                findings=result,
+                resource_node=resource_node,
+            )
+        ) + [scan_info]
     )
 
 

--- a/malware/clamav.py
+++ b/malware/clamav.py
@@ -10,6 +10,9 @@ import subprocess
 import threading
 import time
 
+import github.compliance.model
+import dso.model
+
 import clamav.model
 
 
@@ -76,16 +79,15 @@ def clamscan_version() -> clamav.model.ClamAVVersionInfo:
 
 def scan(
     data: collections.abc.Iterable[bytes],
-    name: str,
-):
+    layer_digest: str,
+    filename: str,
+) -> dso.model.ClamAVMalwareFinding | None:
     sock = socket.socket(
         family=socket.AF_UNIX,
         type=socket.SOCK_STREAM,
     )
     clamav_socket_address = _lookup_clamd_socket()
 
-    start_time = time.time()
-    logger.debug(f'connecting to {clamav_socket_address=}')
     sock.connect(clamav_socket_address)
     sock.send(b'zINSTREAM\x00')
 
@@ -103,7 +105,6 @@ def scan(
     sock.send(struct.pack(b'!L', 0))
 
     receive_done_time = time.time()
-    logger.debug(f'received {total=} octets')
 
     result = None
 
@@ -115,7 +116,7 @@ def scan(
     reader = threading.Thread(target=read_result)
     reader.start()
 
-    def responder(start_time):
+    def responder():
         nonlocal result
         nonlocal content_hash
 
@@ -130,37 +131,40 @@ def scan(
         sock.close()
 
         scan_done_time = time.time()
-
-        result = result.split(':', 1)[1][:-1].strip()
-
-        receive_duration_seconds = receive_done_time - start_time
         scan_duration_seconds = scan_done_time - receive_done_time
 
-        logger.info(f'scan done after {scan_duration_seconds=}')
+        def _virus_name_or_none(
+            raw_result: str,
+        ) -> str | None:
+            '''
+            extract virus name from clamav result
+            "stream: Eicar-Signature FOUND\x00" -> "Eicar-Signature"
 
-        meta = clamav.model.Meta(
-            scanned_octets=total,
-            receive_duration_seconds=receive_duration_seconds,
+            if result indicates no virus, return None
+            '''
+            result = raw_result \
+                .removeprefix('stream: ') \
+                .removesuffix('\x00') \
+                .removesuffix(' FOUND')
+
+            if result == 'OK':
+                return None
+
+            return result
+
+        virus_name_or_none = _virus_name_or_none(result)
+
+        if not virus_name_or_none:
+            return
+
+        return dso.model.ClamAVMalwareFinding(
+            content_digest=f'sha256:{content_hash.hexdigest()}',
+            filename=filename,
+            layer_digest=layer_digest,
+            virus_name=result,
+            octets_count=total,
             scan_duration_seconds=scan_duration_seconds,
-            scanned_content_digest=f'sha256:{content_hash.hexdigest()}',
+            severity=github.compliance.model.Severity.BLOCKER.name,
         )
 
-        if result == 'OK':
-            return clamav.model.ScanResult(
-                status=clamav.model.ScanStatus.SCAN_SUCCEEDED,
-                details='no malware was found',
-                malware_status=clamav.model.MalwareStatus.OK,
-                meta=meta,
-                name=name,
-            )
-
-        else:
-            return clamav.model.ScanResult(
-                status=clamav.model.ScanStatus.SCAN_SUCCEEDED,
-                details=f'malware was found: {result}',
-                malware_status=clamav.model.MalwareStatus.FOUND_MALWARE,
-                meta=meta,
-                name=name,
-            )
-
-    return responder(start_time=start_time)
+    return responder()

--- a/malware/scan.py
+++ b/malware/scan.py
@@ -5,12 +5,8 @@ import logging
 import tarfile
 import tempfile
 
-import gci.componentmodel as cm
-
 import ci.log
-import clamav.client
-import clamav.model
-import clamav.util
+import dso.model
 import oci.client
 import oci.model
 
@@ -21,64 +17,8 @@ logger = logging.getLogger(__name__)
 ci.log.configure_default_logging()
 
 
-def aggregate_scan_result(
-    resource: cm.Resource,
-    results: collections.abc.Iterable[clamav.model.ScanResult],
-    clamav_version_info: clamav.model.ClamAVVersionInfo,
-    name: str=None,
-) -> clamav.model.AggregatedScanResult:
-    count = 0
-    succeeded = True
-    scanned_octets = 0
-    scan_duration_seconds = 0
-    upload_duration_seconds = 0
-    findings = []
-
-    for result in results:
-        count += 1
-        if result.status is clamav.model.ScanStatus.SCAN_FAILED:
-            succeeded = False
-            continue
-
-        scanned_octets += result.meta.scanned_octets
-        scan_duration_seconds += result.meta.scan_duration_seconds
-        upload_duration_seconds += result.meta.receive_duration_seconds
-
-        if result.malware_status is clamav.model.MalwareStatus.OK:
-            continue
-        elif result.malware_status is clamav.model.MalwareStatus.UNKNOWN:
-            raise ValueError('state cannot be unknown if scan succeeded')
-        elif result.malware_status is clamav.model.MalwareStatus.FOUND_MALWARE:
-            findings.append(result)
-        else:
-            raise NotImplementedError(result.malware_status)
-
-    if count == 0:
-        raise ValueError('results-iterator did not contain any elements')
-
-    if succeeded:
-        if len(findings) < 1:
-            malware_status = clamav.model.MalwareStatus.OK
-        else:
-            malware_status = clamav.model.MalwareStatus.FOUND_MALWARE
-    else:
-        malware_status = clamav.model.MalwareStatus.UNKNOWN
-
-    return clamav.model.AggregatedScanResult(
-        resource_url=clamav.util.resource_url_from_resource_access(resource.access),
-        name=name,
-        malware_status=malware_status,
-        findings=findings,
-        scan_count=count,
-        scanned_octets=scanned_octets,
-        scan_duration_seconds=scan_duration_seconds,
-        upload_duration_seconds=upload_duration_seconds,
-        clamav_version_info=clamav_version_info,
-    )
-
-
 def scan_tarfile(tf: tarfile.TarFile) \
-    -> collections.abc.Generator[clamav.model.ScanResult, None, None]:
+    -> collections.abc.Generator[dso.model.ClamAVMalwareFinding, None, None]:
     for tar_info in tf:
         if not tar_info.isfile():
             continue
@@ -88,11 +28,11 @@ def scan_tarfile(tf: tarfile.TarFile) \
             tmp_file.write(data.read())
             tmp_file.seek(0)
 
-            scan_result = malware.clamav.scan(
+            if (scan_result := malware.clamav.scan(
                 data=tmp_file,
                 name=f'{tar_info.name}',
-            )
-            yield scan_result
+            )):
+                yield scan_result
 
 
 def _iter_layers(
@@ -133,8 +73,9 @@ def _iter_layers(
 def scan_oci_image(
     image_reference: str | oci.model.OciImageReference,
     oci_client: oci.client.Client,
-) -> collections.abc.Generator[clamav.model.ScanResult, None, None]:
+) -> collections.abc.Generator[dso.model.ClamAVMalwareFinding, None, None]:
     layer_blobs = tuple(_iter_layers(image_reference=image_reference, oci_client=oci_client))
+    logger.info(f'will scan {len(layer_blobs)} layer blobs')
 
     scan_func = functools.partial(
         scan_oci_blob,
@@ -155,7 +96,8 @@ def scan_oci_blob(
     blob_reference: oci.model.OciBlobRef,
     image_reference: str | oci.model.OciImageReference,
     oci_client: oci.client.Client,
-) -> collections.abc.Generator[clamav.model.ScanResult, None, None]:
+) -> collections.abc.Generator[dso.model.ClamAVMalwareFinding, None, None]:
+    logger.info(f'scanning {blob_reference=}')
     try:
         yield from scan_oci_blob_filewise(
             blob_reference=blob_reference,
@@ -177,7 +119,7 @@ def scan_oci_blob_filewise(
     image_reference: str | oci.model.OciImageReference,
     oci_client: oci.client.Client,
     chunk_size=8096,
-) -> collections.abc.Generator[clamav.model.ScanResult, None, None]:
+) -> collections.abc.Generator[dso.model.ClamAVMalwareFinding, None, None]:
     blob = oci_client.blob(
         image_reference=image_reference,
         digest=blob_reference.digest,
@@ -200,25 +142,27 @@ def scan_oci_blob_filewise(
 
                 data = tf.extractfile(member=tar_info)
 
-                scan_result = malware.clamav.scan(
+                if (scan_result := malware.clamav.scan(
                     data=data,
-                    name=f'{image_reference}:{blob_reference.digest}:{tar_info.name}',
-                )
-                yield scan_result
+                    layer_digest=blob_reference.digest,
+                    filename=tar_info.name,
+                )):
+                    yield scan_result
 
 
 def scan_oci_blob_layerwise(
     blob_reference: oci.model.OciBlobRef,
     image_reference: str | oci.model.OciImageReference,
     oci_client: oci.client.Client,
-) -> collections.abc.Generator[clamav.model.ScanResult, None, None]:
+) -> collections.abc.Generator[dso.model.ClamAVMalwareFinding, None, None]:
     blob = oci_client.blob(
         image_reference=image_reference,
         digest=blob_reference.digest,
     )
 
-    scan_result = malware.clamav.scan(
+    if (scan_result := malware.clamav.scan(
         data=blob.iter_content(chunk_size=tarfile.RECORDSIZE),
-        name=f'{image_reference}:{blob_reference.digest}',
-    )
-    yield scan_result
+        layer_digest=blob_reference.digest,
+        filename=None,
+    )):
+        yield scan_result


### PR DESCRIPTION
Required for finding specific tracking (and rescoring). Use artefact-metadata type `meta/artefact_scan_info` to store which artefacts have been scanned. Previously, this was realised with aggregated malware findings with empty result lists.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
