### PR TITLE
Remove deprecated `cnudie` routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -393,27 +393,10 @@ def init_app(
         suffix='jwks',
     )
 
-    app.add_route( # TODO remove after clients have been switched to /ocm/component
-        '/cnudie/component',
-        components.Component(
-            component_descriptor_lookup=component_descriptor_lookup,
-            version_lookup=version_lookup,
-            version_filter_callback=version_filter_callback,
-            invalid_semver_ok=invalid_semver_ok,
-        ),
-    )
     app.add_route(
         '/ocm/component',
         components.Component(
             component_descriptor_lookup=component_descriptor_lookup,
-            version_lookup=version_lookup,
-            version_filter_callback=version_filter_callback,
-            invalid_semver_ok=invalid_semver_ok,
-        ),
-    )
-    app.add_route( # TODO remove after clients have been switched to /ocm/component/versions
-        '/cnudie/component/versions',
-        components.GreatestComponentVersions(
             version_lookup=version_lookup,
             version_filter_callback=version_filter_callback,
             invalid_semver_ok=invalid_semver_ok,
@@ -427,33 +410,11 @@ def init_app(
             invalid_semver_ok=invalid_semver_ok,
         ),
     )
-    app.add_route( # TODO remove after clients have been switched to /ocm/component/dependencies
-        '/cnudie/component/dependencies',
-        components.ComponentDependencies(
-            component_descriptor_lookup=component_descriptor_lookup,
-            version_lookup=version_lookup,
-            version_filter_callback=version_filter_callback,
-            invalid_semver_ok=invalid_semver_ok,
-        ),
-    )
     app.add_route(
         '/ocm/component/dependencies',
         components.ComponentDependencies(
             component_descriptor_lookup=component_descriptor_lookup,
             version_lookup=version_lookup,
-            version_filter_callback=version_filter_callback,
-            invalid_semver_ok=invalid_semver_ok,
-        ),
-    )
-    app.add_route( # TODO remove after clients have been switched to /ocm/component/responsibles
-        '/cnudie/component/responsibles',
-        components.ComponentResponsibles(
-            component_descriptor_lookup=component_descriptor_lookup,
-            version_lookup=version_lookup,
-            github_api_lookup=github_api_lookup,
-            addressbook_repo_callback=addressbook_repo_callback,
-            addressbook_relpath_callback=addressbook_relpath_callback,
-            github_mappings_relpath_callback=github_mappings_relpath_callback,
             version_filter_callback=version_filter_callback,
             invalid_semver_ok=invalid_semver_ok,
         ),


### PR DESCRIPTION
They have been renamed to `ocm` instead.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
