### PR TITLE
Add runtime artefacts as CRD to extension workflows

### DIFF
--- a/app.py
+++ b/app.py
@@ -516,6 +516,13 @@ def init_app(
         ),
     )
     app.add_route(
+        '/service-extensions/runtime-artefacts',
+        service_extensions.RuntimeArtefacts(
+            namespace_callback=namespace_callback,
+            kubernetes_api_callback=kubernetes_api_callback,
+        ),
+    )
+    app.add_route(
         '/dora/dora-metrics',
         dora.DoraMetrics(
             component_descriptor_lookup=component_descriptor_lookup,

--- a/bdba.py
+++ b/bdba.py
@@ -14,6 +14,7 @@ import ci.log
 import cnudie.iter
 import cnudie.retrieve
 import delivery.client
+import dso.model
 import oci.client
 import protecode.client
 import protecode.scanning
@@ -89,9 +90,15 @@ def scan(
     oci_client: oci.client.Client,
     s3_client: 'botocore.client.S3',
 ):
-    resource_node = k8s.backlog.get_resource_node(
-        backlog_item=backlog_item,
+    if backlog_item.artefact.artefact_kind is not dso.model.ArtefactKind.RESOURCE:
+        logger.warning(
+            f'found unsupported artefact kind {backlog_item.artefact.artefact_kind}, skipping...'
+        )
+        return
+
+    resource_node = k8s.util.get_ocm_node(
         component_descriptor_lookup=component_descriptor_lookup,
+        artefact=backlog_item.artefact,
     )
     groups = [[resource_node]]
 

--- a/bdba.py
+++ b/bdba.py
@@ -323,7 +323,8 @@ def main():
             s3_client=s3_client,
         )
 
-        k8s.backlog.delete_backlog_crd(
+        k8s.util.delete_custom_resource(
+            crd=k8s.model.BacklogItemCrd,
             name=name,
             namespace=namespace,
             kubernetes_api=kubernetes_api,

--- a/issue_replicator/__main__.py
+++ b/issue_replicator/__main__.py
@@ -640,7 +640,8 @@ def main():
             backlog_item=backlog_item,
         )
 
-        k8s.backlog.delete_backlog_crd(
+        k8s.util.delete_custom_resource(
+            crd=k8s.model.BacklogItemCrd,
             name=name,
             namespace=namespace,
             kubernetes_api=kubernetes_api,

--- a/k8s/backlog.py
+++ b/k8s/backlog.py
@@ -387,23 +387,3 @@ def update_backlog_crd(
         # and must not be updated anymore
         if e.status != http.HTTPStatus.NOT_FOUND:
             raise e
-
-
-def delete_backlog_crd(
-    name: str,
-    namespace: str,
-    kubernetes_api: k8s.util.KubernetesApi,
-):
-    try:
-        kubernetes_api.custom_kubernetes_api.delete_namespaced_custom_object(
-            group=k8s.model.BacklogItemCrd.DOMAIN,
-            version=k8s.model.BacklogItemCrd.VERSION,
-            plural=k8s.model.BacklogItemCrd.PLURAL_NAME,
-            namespace=namespace,
-            name=name,
-        )
-    except kubernetes.client.rest.ApiException as e:
-        # if the http status is 404 it is fine because the object should be deleted anyway
-        # this case can occur if two bdba worker processed the same backlog item (edge case)
-        if e.status != http.HTTPStatus.NOT_FOUND:
-            raise e

--- a/k8s/model.py
+++ b/k8s/model.py
@@ -40,6 +40,12 @@ class BacklogItemCrd(Crd):
 
 
 @dataclasses.dataclass(frozen=True)
+class RuntimeArtefactCrd(Crd):
+    KIND = 'RuntimeArtefact'
+    PLURAL_NAME = 'runtimeartefacts'
+
+
+@dataclasses.dataclass(frozen=True)
 class ScanConfiguration:
     name: str
     config: dict

--- a/k8s/runtime_artefacts.py
+++ b/k8s/runtime_artefacts.py
@@ -1,0 +1,153 @@
+'''
+This module defines the data model of a runtime artefact and can be used to maintain the lifecycle
+of runtime artefacts (e.g. creation/iteration).
+'''
+import dataclasses
+import datetime
+import dateutil.parser
+import typing
+
+import dacite
+
+import ci.util
+import dso.model
+
+import k8s.model
+import k8s.util
+
+
+@dataclasses.dataclass(frozen=True)
+class RuntimeArtefact:
+    '''
+    Runtime artefacts depict the dynamic runtime view in contrast to the conceptual design-time view
+    modelled by OCM. However, these runtime artefacts relate to one (or more) static OCM components
+    or artefacts. This relation can be expressed by specifying certain `references` in the
+    `artefact` property.
+    '''
+    creation_date: datetime.datetime
+    artefact: dso.model.ComponentArtefactId
+
+    def as_dict(self) -> dict:
+        return dataclasses.asdict(
+            obj=self,
+            dict_factory=ci.util.dict_to_json_factory,
+        )
+
+    @staticmethod
+    def from_dict(runtime_artefact: dict) -> typing.Self:
+        type_hooks = {
+            datetime.datetime: lambda ts: dateutil.parser.isoparse(ts) if ts else None,
+        }
+
+        return dacite.from_dict(
+            data_class=RuntimeArtefact,
+            data=runtime_artefact,
+            config=dacite.Config(
+                type_hooks=type_hooks,
+                cast=[dso.model.ArtefactKind],
+            ),
+        )
+
+
+def create_runtime_artefact_crd_body(
+    name: str,
+    namespace: str,
+    runtime_artefact: RuntimeArtefact,
+    labels: dict[str, str]=None,
+) -> dict:
+    return {
+        'apiVersion': k8s.model.RuntimeArtefactCrd.api_version(),
+        'kind': k8s.model.RuntimeArtefactCrd.KIND,
+        'metadata': {
+            'name': name,
+            'namespace': namespace,
+            'labels': labels,
+        },
+        'spec': runtime_artefact.as_dict(),
+    }
+
+
+def iter_runtime_artefacts(
+    namespace: str,
+    kubernetes_api: k8s.util.KubernetesApi,
+    labels: dict[str, str]=None,
+) -> tuple[RuntimeArtefact]:
+    if labels:
+        label_selector = k8s.util.create_label_selector(labels=labels)
+    else:
+        label_selector = None
+
+    runtime_artefact_crds = kubernetes_api.custom_kubernetes_api.list_namespaced_custom_object(
+        group=k8s.model.RuntimeArtefactCrd.DOMAIN,
+        version=k8s.model.RuntimeArtefactCrd.VERSION,
+        plural=k8s.model.RuntimeArtefactCrd.PLURAL_NAME,
+        namespace=namespace,
+        label_selector=label_selector,
+    ).get('items')
+
+    return tuple(
+        RuntimeArtefact.from_dict(runtime_artefact_crd.get('spec'))
+        for runtime_artefact_crd in runtime_artefact_crds
+    )
+
+
+def create_runtime_artefact(
+    namespace: str,
+    kubernetes_api: k8s.util.KubernetesApi,
+    artefact: dso.model.ComponentArtefactId,
+    labels: dict[str, str]=None,
+):
+    name = k8s.util.generate_kubernetes_name(
+        name_parts=('runtime-artefact',),
+    )
+
+    runtime_artefact = RuntimeArtefact(
+        creation_date=datetime.datetime.now(tz=datetime.timezone.utc),
+        artefact=artefact,
+    )
+
+    body = create_runtime_artefact_crd_body(
+        name=name,
+        namespace=namespace,
+        runtime_artefact=runtime_artefact,
+        labels=labels,
+    )
+
+    kubernetes_api.custom_kubernetes_api.create_namespaced_custom_object(
+        group=k8s.model.RuntimeArtefactCrd.DOMAIN,
+        version=k8s.model.RuntimeArtefactCrd.VERSION,
+        plural=k8s.model.RuntimeArtefactCrd.PLURAL_NAME,
+        namespace=namespace,
+        body=body,
+    )
+
+
+def create_unique_runtime_artefact(
+    namespace: str,
+    kubernetes_api: k8s.util.KubernetesApi,
+    artefact: dso.model.ComponentArtefactId,
+    labels: dict[str, str]=None,
+) -> bool:
+    '''
+    creates a runtime artefact for the given `artefact`. If there is already an existing runtime
+    artefact which is semantically equal and contains `labels`, the creation is skipped. Returns
+    `True` if a new runtime artefact was created, otherwise `False`.
+    '''
+    runtime_artefacts = iter_runtime_artefacts(
+        namespace=namespace,
+        kubernetes_api=kubernetes_api,
+        labels=labels,
+    )
+
+    for runtime_artefact in runtime_artefacts:
+        if runtime_artefact.artefact == artefact:
+            # artefact is already existing -> don't create a new one
+            return False
+
+    create_runtime_artefact(
+        namespace=namespace,
+        kubernetes_api=kubernetes_api,
+        artefact=artefact,
+        labels=labels,
+    )
+    return True

--- a/k8s/util.py
+++ b/k8s/util.py
@@ -333,3 +333,23 @@ def get_ocm_node(
             f'{component.name}:{component.version}'
         )
         raise ValueError(artefact)
+
+
+def delete_custom_resource(
+    crd: k8s.model.Crd,
+    name: str,
+    namespace: str,
+    kubernetes_api: KubernetesApi,
+):
+    try:
+        kubernetes_api.custom_kubernetes_api.delete_namespaced_custom_object(
+            group=crd.DOMAIN,
+            version=crd.VERSION,
+            plural=crd.PLURAL_NAME,
+            namespace=namespace,
+            name=name,
+        )
+    except kubernetes.client.rest.ApiException as e:
+        # if the http status is 404 it is fine because the resource should be deleted anyway
+        if e.status != http.HTTPStatus.NOT_FOUND:
+            raise e

--- a/k8s/util.py
+++ b/k8s/util.py
@@ -13,6 +13,10 @@ import kubernetes.client.rest
 import kubernetes.config
 import urllib3.exceptions
 
+import cnudie.iter
+import cnudie.retrieve
+import dso.model
+import gci.componentmodel as cm
 import github.compliance.model as gcm
 import model.kubernetes
 
@@ -271,3 +275,61 @@ def iter_scan_configurations(
         ))
 
     return scan_configurations
+
+
+def get_ocm_node(
+    component_descriptor_lookup: cnudie.retrieve.ComponentDescriptorLookupById,
+    artefact: dso.model.ComponentArtefactId,
+) -> cnudie.iter.ResourceNode | cnudie.iter.SourceNode | None:
+    if not dso.model.is_ocm_artefact(artefact.artefact_kind):
+        return None
+
+    component: cm.Component = component_descriptor_lookup(cm.ComponentIdentity(
+        name=artefact.component_name,
+        version=artefact.component_version,
+    )).component
+
+    if artefact.artefact_kind is dso.model.ArtefactKind.RESOURCE:
+        artefacts = component.resources
+    elif artefact.artefact_kind is dso.model.ArtefactKind.SOURCE:
+        artefacts = component.sources
+    else:
+        raise RuntimeError('this line should never be reached')
+
+    for a in artefacts:
+        if a.name != artefact.artefact.artefact_name:
+            continue
+        if a.version != artefact.artefact.artefact_version:
+            continue
+        if a.type != artefact.artefact.artefact_type:
+            continue
+        # currently, we do not set the extraIdentity in the backlog items
+        # TODO-Extra-Id: uncomment below code once extraIdentities are handled properly
+        # if dso.model.normalise_artefact_extra_id(
+        #     artefact_extra_id=a.extraIdentity,
+        #     artefact_version==a.version,
+        # ) != artefact.artefact.normalised_artefact_extra_id(
+        #     remove_duplicate_version=True,
+        # ):
+        #     continue
+
+        # found artefact of backlog item in component's artefacts
+        if artefact.artefact_kind is dso.model.ArtefactKind.RESOURCE:
+            return cnudie.iter.ResourceNode(
+                path=(cnudie.iter.NodePathEntry(component),),
+                resource=a,
+            )
+        elif artefact.artefact_kind is dso.model.ArtefactKind.SOURCE:
+            return cnudie.iter.SourceNode(
+                path=(cnudie.iter.NodePathEntry(component),),
+                source=a,
+            )
+        else:
+            raise RuntimeError('this line should never be reached')
+    else:
+        logger.error(
+            f'could not find {artefact.artefact.artefact_name}:'
+            f'{artefact.artefact.artefact_version} in artefacts of '
+            f'{component.name}:{component.version}'
+        )
+        raise ValueError(artefact)

--- a/malware/__main__.py
+++ b/malware/__main__.py
@@ -358,7 +358,8 @@ def main():
             clamav_config=clamav_config,
         )
 
-        k8s.backlog.delete_backlog_crd(
+        k8s.util.delete_custom_resource(
+            crd=k8s.model.BacklogItemCrd,
             name=name,
             namespace=namespace,
             kubernetes_api=kubernetes_api,

--- a/malware/__main__.py
+++ b/malware/__main__.py
@@ -213,9 +213,15 @@ def scan_and_upload(
     s3_client: 'boto3.resources.factory.s3.ServiceResource | None',
     clamav_config: config.ClamAVConfig,
 ):
-    resource_node = k8s.backlog.get_resource_node(
-        backlog_item=backlog_item,
+    if backlog_item.artefact.artefact_kind is not dso.model.ArtefactKind.RESOURCE:
+        logger.warning(
+            f'found unsupported artefact kind {backlog_item.artefact.artefact_kind}, skipping...'
+        )
+        return
+
+    resource_node = k8s.util.get_ocm_node(
         component_descriptor_lookup=component_descriptor_lookup,
+        artefact=backlog_item.artefact,
     )
 
     if not resource_node.resource.type in clamav_config.artefact_types:

--- a/service_extensions.py
+++ b/service_extensions.py
@@ -295,7 +295,8 @@ class BacklogItems:
         names = req.get_param_as_list('name', required=True)
 
         for name in names:
-            k8s.backlog.delete_backlog_crd(
+            k8s.util.delete_custom_resource(
+                crd=k8s.model.BacklogItemCrd,
                 name=name,
                 namespace=self.namespace_callback(),
                 kubernetes_api=self.kubernetes_api_callback(),


### PR DESCRIPTION
**What this PR does / why we need it**:
This change introduces the handling for a new Kubernetes custom resource definition (CRD) `RuntimeArtefact`. Its purpose is to represent those artefacts, which are not part of OCM but still need to be processed in several extensions of the OCM-Gear, such as the artefact enumerator or the issue replicator. Just as component descriptors are created and uploaded independently of the OCM-Gear, those runtime artefacts should also be created/updated/deleted by external tooling which has knowledge of existing runtime artefacts. Therefore, this change also adds new API routes supporting this request. As soon and as long a CR for a runtime artefact exists, it will be part of the extension machinery just as traditional OCM resources and sources, except they won't be enriched by extra information which was usually retrieved from the component descriptor.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
