### PR TITLE
Modify `_diki_template_vars()` to handle merged findings

### DIFF
--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -576,27 +576,27 @@ def _diki_template_vars(
     def _targets_table(
         targets: list[dict],
     ) -> str:
-        table = ""
+        table = ''
         unique_keys = set()
         for t in targets:
             unique_keys.update(t.keys())
         unique_keys = list(unique_keys)
 
         unique_keys.sort()
-        if "details" in unique_keys:
-            unique_keys.remove("details")
-            unique_keys.append("details")
+        if 'details' in unique_keys:
+            unique_keys.remove('details')
+            unique_keys.append('details')
 
-        column_titles = "|"
-        column_separation = "|"
+        column_titles = '|'
+        column_separation = '|'
         for key in unique_keys:
             column_titles += f' {key} |'
-            column_separation += ":-:|"
+            column_separation += ':-:|'
 
         table += f'{column_titles}\n'
         table += f'{column_separation}\n'
         for t in targets:
-            current_row = "|"
+            current_row = '|'
             for key in unique_keys:
                 if key in t:
                     current_row += f' {t[key]} |'
@@ -646,14 +646,9 @@ def _diki_template_vars(
                     case _:
                         raise TypeError(check.targets) # this line should never be reached
 
-    if len(summary) <= MAX_SUMMARY_SIZE:
-        return {
-            'summary': summary,
-        }
-    else:
-        return {
-            'summary': shortened_summary,
-        }
+    return {
+        'summary': summary if len(summary) <= MAX_SUMMARY_SIZE else shortened_summary,
+    }
 
 
 def _template_vars(

--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -569,54 +569,91 @@ def _diki_template_vars(
     findings_by_versions: dict[str, tuple[AggregatedFinding]],
     summary: str,
 ) -> dict[str, str]:
+    # GitHub has a maximum character limit of 65,536
+    MAX_SUMMARY_SIZE = 60000
     findings_list = list(findings_by_versions.values())
 
+    def _targets_table(
+        targets: list[dict],
+    ) -> str:
+        table = ""
+        unique_keys = set()
+        for t in targets:
+            unique_keys.update(t.keys())
+        unique_keys = list(unique_keys)
+
+        unique_keys.sort()
+        if "details" in unique_keys:
+            unique_keys.remove("details")
+            unique_keys.append("details")
+
+        column_titles = "|"
+        column_separation = "|"
+        for key in unique_keys:
+            column_titles += f' {key} |'
+            column_separation += ":-:|"
+
+        table += f'{column_titles}\n'
+        table += f'{column_separation}\n'
+        for t in targets:
+            current_row = "|"
+            for key in unique_keys:
+                if key in t:
+                    current_row += f' {t[key]} |'
+                else:
+                    current_row += ' |'
+            table += f'{current_row}\n'
+        return table
+
+    shortened_summary = summary
     for findings in findings_list:
         for finding in findings:
 
             finging_rule = finding.finding.data
-            summary += '\n'
-            summary += f'# Failed {finging_rule.ruleset_id}:{finging_rule.ruleset_version}'
-            summary += f' rule with ID {finging_rule.rule_id}\n'
-            summary += '\n'
-            summary += '### Failed checks:\n'
+            finding_str = '\n'
+            finding_str += f'# Failed {finging_rule.ruleset_id}:{finging_rule.ruleset_version}'
+            finding_str += f' rule with ID {finging_rule.rule_id}\n'
+            finding_str += '\n'
+            finding_str += '### Failed checks:\n'
+
+            summary += finding_str
+            shortened_summary += finding_str
 
             for check in finging_rule.checks:
-                summary += '\n'
-                summary += f'Message: {check.message}\n'
-                summary += 'Targets:\n'
-                summary += '\n'
+                check_msg_str = '\n'
+                check_msg_str += f'Message: {check.message}\n'
+                check_msg_str += 'Targets:\n'
+                check_msg_str += '\n'
 
-                unique_keys = set()
-                for t in check.targets:
-                    unique_keys.update(t.keys())
-                unique_keys = list(unique_keys)
+                summary += check_msg_str
+                shortened_summary += check_msg_str
 
-                unique_keys.sort()
-                if "details" in unique_keys:
-                    unique_keys.remove("details")
-                    unique_keys.append("details")
+                match check.targets:
+                    # process merged checks
+                    case dict():
+                        for key, value in check.targets.items():
+                            shortened_summary += f'{key}: {len(value)} targets\n'
+                            summary += '<details>\n'
+                            summary += f'<summary>{key}:</summary>\n'
+                            summary += '\n'
+                            summary += _targets_table(value)
+                            summary += '</details>\n'
+                            summary += '\n'
+                    # process single checks
+                    case list():
+                        shortened_summary += f'{len(check.targets)} targets\n'
+                        summary += _targets_table(check.targets)
+                    case _:
+                        raise TypeError(check.targets) # this line should never be reached
 
-                column_titles = "|"
-                column_separation = "|"
-                for key in unique_keys:
-                    column_titles += f' {key} |'
-                    column_separation += ":-:|"
-
-                summary += f'{column_titles}\n'
-                summary += f'{column_separation}\n'
-                for t in check.targets:
-                    current_row = "|"
-                    for key in unique_keys:
-                        if key in t:
-                            current_row += f' {t[key]} |'
-                        else:
-                            current_row += ' |'
-                    summary += f'{current_row}\n'
-
-    return {
-        'summary': summary,
-    }
+    if len(summary) <= MAX_SUMMARY_SIZE:
+        return {
+            'summary': summary,
+        }
+    else:
+        return {
+            'summary': shortened_summary,
+        }
 
 
 def _template_vars(


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves `_diki_template_vars()` function to handle merged diki findings. These findings are from compliance checks on more than 1 evaluated instance.

It also places a hard limit of `60,000` character to the full returned summary. When this limit is exceeded the returned summary is in a shortened format. This is done to avoid reaching GitHub's character limit of `65,536` for Issues, PRs, comments, etc.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
