### PR TITLE
Add content-iterator to BDBA scans

### DIFF
--- a/bdba/scanning.py
+++ b/bdba/scanning.py
@@ -19,10 +19,8 @@ import delivery.client
 import dso.cvss
 import dso.labels
 import dso.model
-import gci.oci
 import oci.client
 import ocm
-import tarutil
 
 import bdba.assessments
 import bdba.client
@@ -149,92 +147,37 @@ class ResourceGroupProcessor:
     def scan_request(
         self,
         resource_node: cnudie.iter.ResourceNode,
+        content_iterator: collections.abc.Generator[bytes, None, None],
         known_artifact_scans: tuple[bm.Product],
-        s3_client: 'botocore.client.S3',
     ) -> bm.ScanRequest:
         component = resource_node.component
         resource = resource_node.resource
-
         display_name = f'{resource.name}_{resource.version}_{component.name}'.replace('/', '_')
 
-        if resource.type is ocm.ArtefactType.OCI_IMAGE:
-            # find product existing bdba scans (if any)
-            component_artifact_metadata = bdba.util.component_artifact_metadata(
-                resource_node=resource_node,
-                omit_resource_version=False,
-                oci_client=self.oci_client
-            )
-            target_product_id = bdba.util._matching_analysis_result_id(
-                component_artifact_metadata=component_artifact_metadata,
-                analysis_results=known_artifact_scans,
-            )
-            if target_product_id:
-                logger.info(f'{display_name=}: found {target_product_id=}')
-            else:
-                logger.info(f'{display_name=}: did not find old scan')
+        component_artifact_metadata = bdba.util.component_artifact_metadata(
+            resource_node=resource_node,
+            omit_resource_version=False,
+            oci_client=self.oci_client
+        )
 
-            def iter_content():
-                image_reference = gci.oci.image_ref_with_digest(
-                    image_reference=resource.access.imageReference,
-                    digest=resource.digest,
-                    oci_client=self.oci_client,
-                )
-                yield from oci.image_layers_as_tarfile_generator(
-                    image_reference=image_reference,
-                    oci_client=self.oci_client,
-                    include_config_blob=False,
-                    fallback_to_first_subimage_if_index=True,
-                )
+        target_product_id = bdba.util._matching_analysis_result_id(
+            component_artifact_metadata=component_artifact_metadata,
+            analysis_results=known_artifact_scans,
+        )
 
-            return bm.ScanRequest(
-                component=component,
-                artefact=resource,
-                scan_content=iter_content(),
-                display_name=display_name,
-                target_product_id=target_product_id,
-                custom_metadata=component_artifact_metadata,
-            )
-        elif resource.type == 'application/tar+vm-image-rootfs':
-            # hardcoded semantics for vm-images:
-            # merge all appropriate (tar)artifacts into one big tararchive
-            component_artifact_metadata = bdba.util.component_artifact_metadata(
-                resource_node=resource_node,
-                omit_resource_version=False,
-                oci_client=self.oci_client
-            )
-            target_product_id = bdba.util._matching_analysis_result_id(
-                component_artifact_metadata=component_artifact_metadata,
-                analysis_results=known_artifact_scans,
-            )
-
-            if target_product_id:
-                logger.info(f'{display_name=}: found {target_product_id=}')
-            else:
-                logger.info(f'{display_name=}: did not find old scan')
-
-            # hardcode assumption about all accesses being of s3-type
-            def as_blob_descriptors():
-                name = resource.extraIdentity.get('platform', 'dummy')
-
-                access: ocm.S3Access = resource.access
-                yield cnudie.access.s3_access_as_blob_descriptor(
-                    s3_client=s3_client,
-                    s3_access=access,
-                    name=name,
-                )
-
-            return bm.ScanRequest(
-                component=component,
-                artefact=resource,
-                scan_content=tarutil.concat_blobs_as_tarstream(
-                    blobs=as_blob_descriptors(),
-                ),
-                display_name=display_name,
-                target_product_id=target_product_id,
-                custom_metadata=component_artifact_metadata,
-            )
+        if target_product_id:
+            logger.info(f'{display_name=}: found {target_product_id=}')
         else:
-            raise NotImplementedError(resource.type)
+            logger.info(f'{display_name=}: did not find old scan')
+
+        return bm.ScanRequest(
+            component=component,
+            artefact=resource,
+            scan_content=content_iterator,
+            display_name=display_name,
+            target_product_id=target_product_id,
+            custom_metadata=component_artifact_metadata,
+        )
 
     def process_scan_request(
         self,
@@ -340,8 +283,8 @@ class ResourceGroupProcessor:
     def process(
         self,
         resource_node: cnudie.iter.ResourceNode,
+        content_iterator: collections.abc.Generator[bytes, None, None],
         known_scan_results: tuple[bm.Product],
-        s3_client: 'botocore.client.S3',
         processing_mode: bm.ProcessingMode,
         delivery_client: delivery.client.DeliveryServiceClient=None,
         license_cfg: image_scan.LicenseCfg=None,
@@ -365,8 +308,8 @@ class ResourceGroupProcessor:
 
         scan_request = self.scan_request(
             resource_node=resource_node,
+            content_iterator=content_iterator,
             known_artifact_scans=known_scan_results,
-            s3_client=s3_client,
         )
         try:
             scan_result = self.process_scan_request(


### PR DESCRIPTION
Useful to support various artefact types.
Can be used as a callback for code which should not bother with resolving ocm artefacts.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
