### PR TITLE
Extend greatest_component_versions to support filtering by date range

### DIFF
--- a/app.py
+++ b/app.py
@@ -435,6 +435,7 @@ def init_app(
     app.add_route(
         '/ocm/component/versions',
         components.GreatestComponentVersions(
+            component_descriptor_lookup=component_descriptor_lookup,
             version_lookup=version_lookup,
             version_filter_callback=version_filter_callback,
             invalid_semver_ok=invalid_semver_ok,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends the greatest_component_versions route in the delivery-service to support filtering by a specified date range. Users can now provide optional start_date and end_date parameters to retrieve component versions within a specific timeframe. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR is dependent on another [PR](https://github.com/gardener/cc-utils/pull/1050). Please ensure both are reviewed together to maintain compatibility.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
