### PR TITLE
Expose prometheus metrics to `/metrics` endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ import metadata
 import middleware.auth
 import middleware.cors
 import middleware.errors
+import middleware.prometheus
 import middleware.route_feature_check as rfc
 import osinfo
 import paths
@@ -360,6 +361,10 @@ def add_routes(
         path='/dora/dora-metrics',
         handler=dora.DoraMetrics,
     )
+    app.router.add_view(
+        path='/metrics',
+        handler=middleware.prometheus.Metrics,
+    )
 
     return app
 
@@ -401,6 +406,8 @@ async def initialise_app():
         middlewares=middlewares,
         client_max_size=0, # max request body size is already configured via ingress
     )
+
+    app = middleware.prometheus.add_prometheus_middleware(app=app)
 
     app = add_app_context_vars(
         app=app,

--- a/local-setup/kind/cluster/values-prometheus.yaml
+++ b/local-setup/kind/cluster/values-prometheus.yaml
@@ -1,0 +1,13 @@
+config:
+  global:
+    scrape_interval: 15s
+  scrape_configs:
+  - job_name: delivery_service
+    static_configs:
+    - targets:
+      - delivery-service.delivery.svc.cluster.local:8080
+
+ingress:
+  class: nginx
+  hosts:
+    - prometheus

--- a/local-setup/kind/kind-update.sh
+++ b/local-setup/kind/kind-update.sh
@@ -31,10 +31,11 @@ OCM_GEAR_VERSION="${OCM_GEAR_VERSION:-$(ocm show versions ${OCM_GEAR_COMPONENT_R
 COMPONENT_DESCRIPTORS=$(ocm get cv ${OCM_GEAR_COMPONENT_REF}:${OCM_GEAR_VERSION} -o yaml -r)
 echo "Installing OCM-Gear with version $OCM_GEAR_VERSION"
 
-DELIVERY_SERVICE_CHART=$(echo "${COMPONENT_DESCRIPTORS}" | yq eval '.component.resources.[] | select(.name == "delivery-service" and .type == "helmChart/v1") | .access.imageReference')
-DELIVERY_DASHBOARD_CHART=$(echo "${COMPONENT_DESCRIPTORS}" | yq eval '.component.resources.[] | select(.name == "delivery-dashboard" and .type == "helmChart/v1") | .access.imageReference')
-EXTENSIONS_CHART=$(echo "${COMPONENT_DESCRIPTORS}" | yq eval '.component.resources.[] | select(.name == "extensions" and .type == "helmChart/v1") | .access.imageReference')
-DELIVERY_DATABASE_CHART=$(echo "${COMPONENT_DESCRIPTORS}" | yq eval '.component.resources.[] | select(.name == "postgresql" and .type == "helmChart/v1") | .access.imageReference')
+DELIVERY_SERVICE_CHART=$(echo "${COMPONENT_DESCRIPTORS}" | yq eval '.component.resources.[] | select(.name == "delivery-service" and .type | test("helmChart")) | .access.imageReference')
+DELIVERY_DASHBOARD_CHART=$(echo "${COMPONENT_DESCRIPTORS}" | yq eval '.component.resources.[] | select(.name == "delivery-dashboard" and .type | test("helmChart")) | .access.imageReference')
+EXTENSIONS_CHART=$(echo "${COMPONENT_DESCRIPTORS}" | yq eval '.component.resources.[] | select(.name == "extensions" and .type | test("helmChart")) | .access.imageReference')
+DELIVERY_DATABASE_CHART=$(echo "${COMPONENT_DESCRIPTORS}" | yq eval '.component.resources.[] | select(.name == "postgresql" and .type | test("helmChart")) | .access.imageReference')
+PROMETHEUS_CHART=$(echo "${COMPONENT_DESCRIPTORS}" | yq eval '.component.resources.[] | select(.name == "prometheus" and .type | test("helmChart")) | .access.imageReference')
 
 kubectl config set-context --current --namespace=$NAMESPACE
 
@@ -72,6 +73,16 @@ helm upgrade extensions oci://${EXTENSIONS_CHART%:*} \
     --version ${EXTENSIONS_CHART#*:} \
     --values ${CHART}/values-extensions.yaml
 
+echo ">>> Installing prometheus from ${PROMETHEUS_CHART}"
+helm upgrade prometheus oci://${PROMETHEUS_CHART%:*} \
+    --namespace $NAMESPACE \
+    --version ${PROMETHEUS_CHART#*:} \
+    --values ${CHART}/values-prometheus.yaml
+
 # port-forward to the new delivery-service pods
 lsof -i tcp:5000 | grep kubectl | awk 'NR!=1 {print $2}' | xargs kill
 kubectl port-forward service/delivery-service 5000:8080 > /dev/null &
+
+# port-forward to the new prometheus pod
+lsof -i tcp:9090 | grep kubectl | awk 'NR!=1 {print $2}' | xargs kill
+kubectl port-forward service/prometheus 9090:8080 > /dev/null &

--- a/middleware/prometheus.py
+++ b/middleware/prometheus.py
@@ -1,0 +1,73 @@
+import datetime
+
+import aiohttp.typedefs
+import aiohttp.web
+import prometheus_client
+
+import middleware.auth
+
+
+APP_REQUEST_LATENCY_SECONDS = 'request_latency_seconds'
+APP_REQUESTS_CONCURRENCY = 'requests_concurrency'
+APP_REQUESTS_TOTAL = 'requests_total'
+
+
+@middleware.auth.noauth
+class Metrics(aiohttp.web.View):
+    async def get(self):
+        '''
+        ---
+        tags:
+        - Metrics
+        produces:
+        - text/plain
+        responses:
+          "200":
+            description: Successful operation.
+        '''
+        return aiohttp.web.Response(
+            body=prometheus_client.generate_latest(),
+            content_type='text/plain',
+        )
+
+
+def add_prometheus_middleware(
+    app: aiohttp.web.Application,
+) -> aiohttp.typedefs.Middleware:
+
+    @aiohttp.web.middleware
+    async def middleware(
+        request: aiohttp.web.Request,
+        handler: aiohttp.typedefs.Handler,
+    ) -> aiohttp.web.StreamResponse:
+        start_time = datetime.datetime.now()
+        request.app[APP_REQUESTS_CONCURRENCY].labels(request.path, request.method).inc()
+
+        response = await handler(request)
+
+        latency = datetime.datetime.now() - start_time
+        request.app[APP_REQUEST_LATENCY_SECONDS].labels(request.path, request.method).observe(latency.total_seconds()) # noqa: E501
+        request.app[APP_REQUESTS_CONCURRENCY].labels(request.path, request.method).dec()
+        request.app[APP_REQUESTS_TOTAL].labels(request.path, request.method, response.status).inc()
+
+        return response
+
+    app[APP_REQUEST_LATENCY_SECONDS] = prometheus_client.Histogram(
+        name=APP_REQUEST_LATENCY_SECONDS,
+        documentation='Request latency (seconds)',
+        labelnames=['endpoint', 'method'],
+    )
+    app[APP_REQUESTS_CONCURRENCY] = prometheus_client.Gauge(
+        name=APP_REQUESTS_CONCURRENCY,
+        documentation='Requests currently in progress',
+        labelnames=['endpoint', 'method'],
+    )
+    app[APP_REQUESTS_TOTAL] = prometheus_client.Counter(
+        name=APP_REQUESTS_TOTAL,
+        documentation='Requests total',
+        labelnames=['endpoint', 'method', 'status'],
+    )
+
+    app.middlewares.insert(0, middleware)
+
+    return app

--- a/requirements.service.txt
+++ b/requirements.service.txt
@@ -6,6 +6,7 @@ dataclasses-json
 github3-py
 htmllistparse
 jsonschema
+prometheus_client
 psycopg[binary]
 pyjwt
 pyyaml


### PR DESCRIPTION
**What this PR does / why we need it**:
- adds external `prometheus` resource to component descriptor
- enables optional `prometheus` feature by passing `--prometheus` argument
- if the feature is enabled, it will expose an additional `/metrics` endpoint which can be scraped by Prometheus
- Prometheus endpoint will be available under `<delivery-service-url>/prometheus`
- by now, 3 metrics are going to be monitored:
   -> `request_latency_seconds`
   -> `requests_in_progress_total`
   -> `requests_total`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
