### PR TITLE
Unify rescoring rule sets

### DIFF
--- a/bdba/__main__.py
+++ b/bdba/__main__.py
@@ -164,7 +164,7 @@ def scan(
         known_scan_results=known_scan_results,
         delivery_client=delivery_client,
         license_cfg=bdba_config.license_cfg,
-        cve_rescoring_rules=bdba_config.cve_rescoring_rules,
+        cve_rescoring_ruleset=bdba_config.cve_rescoring_ruleset,
         auto_assess_max_severity=bdba_config.auto_assess_max_severity,
         use_product_cache=False,
         delete_inactive_products_after_seconds=bdba_config.delete_inactive_products_after_seconds,

--- a/bdba/rescore.py
+++ b/bdba/rescore.py
@@ -34,7 +34,7 @@ def rescore(
     bdba_client: bdba.client.BDBAApi,
     scan_result: bm.AnalysisResult,
     scanned_element: cnudie.iter.ResourceNode,
-    rescoring_rules: collections.abc.Sequence[rm.RescoringRule],
+    cve_rescoring_ruleset: rm.CveRescoringRuleSet,
     max_rescore_severity: dso.cvss.CVESeverity=dso.cvss.CVESeverity.MEDIUM,
     assessed_vulns_by_component: dict[str, list[str]]=collections.defaultdict(list),
 ) -> dict[str, list[str]]:
@@ -82,7 +82,7 @@ def rescore(
                 continue
 
             matching_rules = ru.matching_rescore_rules(
-                rescoring_rules=rescoring_rules,
+                rescoring_rules=cve_rescoring_ruleset.rules,
                 categorisation=categorisation,
                 cvss=v.cvss,
             )

--- a/bdba/scanning.py
+++ b/bdba/scanning.py
@@ -288,7 +288,7 @@ class ResourceGroupProcessor:
         processing_mode: bm.ProcessingMode,
         delivery_client: delivery.client.DeliveryServiceClient=None,
         license_cfg: image_scan.LicenseCfg=None,
-        cve_rescoring_rules: tuple[rescore.model.RescoringRule]=tuple(),
+        cve_rescoring_ruleset: rescore.model.CveRescoringRuleSet=None,
         auto_assess_max_severity: dso.cvss.CVESeverity=dso.cvss.CVESeverity.MEDIUM,
         use_product_cache: bool=True,
         delete_inactive_products_after_seconds: int=None,
@@ -370,12 +370,12 @@ class ResourceGroupProcessor:
             assessed_vulns_by_component=assessed_vulns_by_component,
         )
 
-        if cve_rescoring_rules:
+        if cve_rescoring_ruleset:
             assessed_vulns_by_component = bdba.rescore.rescore(
                 bdba_client=self.bdba_client,
                 scan_result=scan_result,
                 scanned_element=scanned_element,
-                rescoring_rules=cve_rescoring_rules,
+                cve_rescoring_ruleset=cve_rescoring_ruleset,
                 max_rescore_severity=auto_assess_max_severity,
                 assessed_vulns_by_component=assessed_vulns_by_component,
             )


### PR DESCRIPTION
Avoid duplication of rescoring rule sets across delivery-service and extension configs.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
