### PR TITLE
fix: Properly filter for overdue findings when jumping to delivery-dashboard

### DIFF
--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -958,6 +958,8 @@ def _create_or_update_issue(
         extra=extra_title,
     )
 
+    is_overdue = latest_processing_date < datetime.date.today()
+
     template_variables = _template_vars(
         cfg_name=cfg_name,
         issue_replicator_config=issue_replicator_config,
@@ -967,7 +969,7 @@ def _create_or_update_issue(
         findings=findings,
         artefact_versions_without_scan=artefact_versions_without_scan,
         latest_processing_date=latest_processing_date,
-        sprint_name=sprint_name,
+        sprint_name='Overdue' if is_overdue else sprint_name,
     )
 
     for issue_template_cfg in issue_replicator_config.github_issue_template_cfgs:
@@ -978,7 +980,7 @@ def _create_or_update_issue(
 
     body = issue_template_cfg.body.format(**template_variables)
 
-    if latest_processing_date < datetime.date.today():
+    if is_overdue:
         labels.add(gci._label_overdue)
 
     if not is_scanned:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
