### PR TITLE
adjust to upstream refactoring (cc-utils)

### DIFF
--- a/components.py
+++ b/components.py
@@ -24,11 +24,11 @@ import cnudie.retrieve
 import cnudie.retrieve_async
 import cnudie.util
 import dso.model
-import gci.oci
 import github.util
 import oci.client_async
 import oci.model as om
 import ocm
+import ocm.oci
 import version as versionutil
 
 import compliance_summary as cs
@@ -198,7 +198,7 @@ async def _component_descriptor(
         blob_fobj = io.BytesIO(raw)
 
         with tarfile.open(fileobj=blob_fobj, mode='r') as tf:
-            component_descriptor_info = tf.getmember(gci.oci.component_descriptor_fname)
+            component_descriptor_info = tf.getmember(ocm.oci.component_descriptor_fname)
             component_descriptor_bytes = tf.extractfile(component_descriptor_info).read()
 
         if raw:

--- a/delivery_db_backup.py
+++ b/delivery_db_backup.py
@@ -13,7 +13,6 @@ import ci.util
 import cnudie.iter
 import cnudie.purge
 import cnudie.retrieve
-import cnudie.upload
 import cnudie.util
 import delivery.client
 import model.container_registry
@@ -21,6 +20,7 @@ import model.delivery_db
 import oci.auth
 import oci.client
 import ocm
+import ocm.upload
 import version
 
 import config
@@ -397,9 +397,9 @@ def main():
     )
     component = component_descriptor.component
 
-    cnudie.upload.upload_component_descriptor(
+    ocm.upload.upload_component_descriptor(
         component_descriptor=component_descriptor,
-        on_exist=cnudie.upload.UploadMode.OVERWRITE,
+        on_exist=ocm.upload.UploadMode.OVERWRITE,
         oci_client=oci_client,
     )
 


### PR DESCRIPTION
- rename: cnudie.upload -> ocm.upload
- inline gci.oci's "to-digest"-code

ref: https://github.com/gardener/cc-utils/pull/1081