### PR TITLE
Fallback to lookup blob size in oci-manifest

### DIFF
--- a/bdba/__main__.py
+++ b/bdba/__main__.py
@@ -167,7 +167,10 @@ def scan(
 
     elif access.type is ocm.AccessType.LOCAL_BLOB:
         ocm_repo = resource_node.component.current_ocm_repo
-        image_reference = ocm_repo.component_oci_ref(resource_node.component.name)
+        image_reference = ocm_repo.component_version_oci_ref(
+            name=resource_node.component.name,
+            version=resource_node.component.version,
+        )
 
         content_iterator = ocm_util.iter_local_blob_content(
             access=access,

--- a/cli/_bdba.py
+++ b/cli/_bdba.py
@@ -299,7 +299,10 @@ def scan(
 
             elif access.type is ocm.AccessType.LOCAL_BLOB:
                 ocm_repo = resource_node.component.current_ocm_repo
-                image_reference = ocm_repo.component_oci_ref(resource_node.component.name)
+                image_reference = ocm_repo.component_version_oci_ref(
+                    name=resource_node.component.name,
+                    version=resource_node.component.version,
+                )
 
                 content_iterator = ocm_util.iter_local_blob_content(
                     access=access,


### PR DESCRIPTION
local blob size is optional

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
