### PR TITLE
Fix diki templates when finding targets are `None`

### DIFF
--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -666,7 +666,7 @@ def _diki_template_vars(
         finging_rule = finding.finding.data
         finding_str = '\n'
         finding_str += f'# Failed {finging_rule.ruleset_id}:{finging_rule.ruleset_version}'
-        finding_str += f' rule with ID {finging_rule.rule_id}\n'
+        finding_str += f' rule with ID {finging_rule.rule_id} - {finging_rule.severity}\n'
         finding_str += '\n'
         finding_str += '### Failed checks:\n'
 
@@ -686,6 +686,10 @@ def _diki_template_vars(
                 # process merged checks
                 case dict():
                     for key, value in check.targets.items():
+                        if value is None:
+                            shortened_summary += f'{key}: 0 targets\n'
+                            summary += f'{key}: 0 targets\n'
+                            continue
                         shortened_summary += f'{key}: {len(value)} targets\n'
                         summary += '<details>\n'
                         summary += f'<summary>{key}:</summary>\n\n'
@@ -693,8 +697,15 @@ def _diki_template_vars(
                         summary += '</details>\n\n'
                 # process single checks
                 case list():
+                    if len(check.targets) == 0:
+                        shortened_summary += '0 targets\n'
+                        summary += '0 targets\n'
+                        continue
                     shortened_summary += f'{len(check.targets)} targets\n'
                     summary += _targets_table(check.targets)
+                case None:
+                    shortened_summary += '0 targets\n'
+                    summary += '0 targets\n'
                 case _:
                     raise TypeError(check.targets) # this line should never be reached
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Diki issues template now works with `None` finding targets.
```
