### PR TITLE
refactor: import dataclasses from cc-utils / pipeline-template

### DIFF
--- a/bdba/scanning.py
+++ b/bdba/scanning.py
@@ -14,7 +14,6 @@ import ci.log
 import cnudie.access
 import cnudie.iter
 import cnudie.retrieve
-import concourse.model.traits.image_scan as image_scan
 import delivery.client
 import dso.cvss
 import dso.labels
@@ -283,7 +282,7 @@ class ResourceGroupProcessor:
         known_scan_results: tuple[bm.Product],
         processing_mode: bm.ProcessingMode,
         delivery_client: delivery.client.DeliveryServiceClient=None,
-        license_cfg: image_scan.LicenseCfg=None,
+        license_cfg: config.LicenseCfg=None,
         cve_rescoring_ruleset: rescore.model.CveRescoringRuleSet=None,
         auto_assess_max_severity: dso.cvss.CVESeverity=dso.cvss.CVESeverity.MEDIUM,
         use_product_cache: bool=True,

--- a/bdba/util.py
+++ b/bdba/util.py
@@ -9,12 +9,12 @@ import logging
 
 import ci.log
 import cnudie.iter
-import concourse.model.traits.image_scan as image_scan
 import delivery.client
 import dso.model
 import github.compliance.model as gcm
 import github.compliance.report as gcr
 
+import config
 import bdba.model as bm
 
 
@@ -47,7 +47,7 @@ def iter_existing_findings(
 def iter_artefact_metadata(
     scanned_element: cnudie.iter.ResourceNode,
     scan_result: bm.AnalysisResult,
-    license_cfg: image_scan.LicenseCfg=None,
+    license_cfg: config.LicenseCfg=None,
     delivery_client: delivery.client.DeliveryServiceClient=None,
 ) -> collections.abc.Generator[dso.model.ArtefactMetadata, None, None]:
     now = datetime.datetime.now(tz=datetime.timezone.utc)


### PR DESCRIPTION
Reduce dependencies from delivery-service-repository towards cc-utils (in particular such dependenceis against cc-util's pipeline-template).

As GithubIssueTemplateCfg is quite a trivial datastructure, copy it for now (will be deduplicated again by planned mv of upstream github.compliance-package - which is currently blocked by remaining, pipeline-based scans (CX + OS-id), yet to be migrated into ocm-gear-extensions).

LicenseCfg was not longer used within cc-utils.

