### PR TITLE
pass token-lookups to deliveryservice-client

### DIFF
--- a/artefact_enumerator.py
+++ b/artefact_enumerator.py
@@ -664,7 +664,7 @@ def main():
             routes=delivery.client.DeliveryServiceRoutes(
                 base_url=delivery_service_url,
             ),
-            cfg_factory=cfg_factory,
+            auth_token_lookup=lookups.github_auth_token_lookup,
         )
 
         component_descriptor_lookup = lookups.init_component_descriptor_lookup(

--- a/bdba/__main__.py
+++ b/bdba/__main__.py
@@ -326,7 +326,7 @@ def main():
         routes=delivery.client.DeliveryServiceRoutes(
             base_url=delivery_service_url,
         ),
-        cfg_factory=cfg_factory,
+        auth_token_lookup=lookups.github_auth_token_lookup,
     )
 
     oci_client = lookups.semver_sanitising_oci_client(

--- a/delivery_db_backup.py
+++ b/delivery_db_backup.py
@@ -341,7 +341,7 @@ def main():
         routes=delivery.client.DeliveryServiceRoutes(
             base_url=delivery_service_url,
         ),
-        cfg_factory=cfg_factory,
+        auth_token_lookup=lookups.github_auth_token_lookup,
     )
 
     greatest_versions = delivery_service_client.greatest_component_versions(

--- a/issue_replicator/__main__.py
+++ b/issue_replicator/__main__.py
@@ -486,7 +486,7 @@ def main():
         routes=delivery.client.DeliveryServiceRoutes(
             base_url=delivery_service_url,
         ),
-        cfg_factory=cfg_factory,
+        auth_token_lookup=lookups.github_auth_token_lookup,
     )
 
     component_descriptor_lookup = lookups.init_component_descriptor_lookup(

--- a/lookups.py
+++ b/lookups.py
@@ -408,3 +408,18 @@ def github_repo_lookup(
         return gh_api.repository(org, repo)
 
     return github_repo_lookup
+
+
+def github_auth_token_lookup(url: str, /):
+    '''
+    an implementation of delivery.client.AuthTokenLookup
+    '''
+    import ccc.github
+    import model.base
+
+    try:
+        github_cfg = ccc.github.github_cfg_for_repo_url(url)
+    except model.base.ConfigElementNotFoundError:
+        return None
+
+    return github_cfg.credentials().auth_token()

--- a/malware/__main__.py
+++ b/malware/__main__.py
@@ -319,7 +319,7 @@ def main():
         routes=delivery.client.DeliveryServiceRoutes(
             base_url=delivery_service_url,
         ),
-        cfg_factory=cfg_factory,
+        auth_token_lookup=lookups.github_auth_token_lookup,
     )
 
     oci_client = lookups.semver_sanitising_oci_client(


### PR DESCRIPTION
Adjust to upstream refactoring from:

https://github.com/gardener/cc-utils/pull/1102


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Slightly reduce dependencies towards Gardener-CICD. Pass-in auth-token-lookup thus making delivery-service-client no longer (directly) depend on "CfgFactory".
```
