### PR TITLE
Only use sprints from compliance snapshots for issue replication

### DIFF
--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -55,7 +55,7 @@ class AggregatedFinding:
 
     def calculate_latest_processing_date(
         self,
-        sprints: tuple[datetime.date],
+        sprints: collections.abc.Iterable[datetime.date],
         max_processing_days: gcm.MaxProcessingTimesDays=None,
     ) -> datetime.date | None:
         if not self.severity:


### PR DESCRIPTION
**What this PR does / why we need it**:
Compliance snapshots are only being created for sprints of a configured date interval. However, as of before this change, the issue replicator considered all sprints returned by the delivery-service api and grouped the open findings among these sprints. As not all of these sprints must have a respective compliance snapshots (i.e. if the sprint is not part of the configured date interval), the finding is not being reported in the GitHub issues.
To fix this, this change only considers the sprints determined from the compliance snapshots and groups the findings among these sprints. That way, the configured interval for the artefact enumerator is the single sourth of truth and all findings are being reported only for these sprints.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
