### PR TITLE
Add `bootstrapping` helm-chart and volume mounts for dedicated secrets

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -150,6 +150,9 @@ delivery-service:
               attribute: delivery-db-backup.image.repository
             - ref: ocm-resource:extensions.tag
               attribute: delivery-db-backup.image.tag
+          - name: bootstrapping
+            dir: charts/bootstrapping
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/ocm-gear
         release:
           nextversion: bump_minor
           release_notes_policy: disabled

--- a/charts/bootstrapping/Chart.yaml
+++ b/charts/bootstrapping/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: bootstrapping
+version: 0.1.0

--- a/charts/bootstrapping/templates/helpers.tpl
+++ b/charts/bootstrapping/templates/helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "secret" -}}
+{{- range $secret_element_name, $value := $ }}
+  {{ $secret_element_name }}: |{{ toYaml $value | nindent 4 }}
+{{- end }}
+{{- end -}}

--- a/charts/bootstrapping/templates/secrets.yaml
+++ b/charts/bootstrapping/templates/secrets.yaml
@@ -1,0 +1,74 @@
+{{- if $secrets := .Values.secrets }}
+{{- if $secrets.aws }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-factory-aws
+type: Opaque
+stringData: {{ include "secret" $secrets.aws }}
+---
+{{- end }}
+{{- if $secrets.bdba }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-factory-bdba
+type: Opaque
+stringData: {{ include "secret" $secrets.bdba }}
+---
+{{- end }}
+{{- if (index $secrets "delivery-db") }} # indexing required since `-` is not allowed in variable names
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-factory-delivery-db
+type: Opaque
+stringData: {{ include "secret" (index $secrets "delivery-db") }}
+---
+{{- end }}
+{{- if $secrets.github }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-factory-github
+type: Opaque
+stringData: {{ include "secret" $secrets.github }}
+---
+{{- end }}
+{{- if $secrets.kubernetes }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-factory-kubernetes
+type: Opaque
+stringData: {{ include "secret" $secrets.kubernetes }}
+---
+{{- end }}
+{{- if (index $secrets "oauth-cfg") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-factory-oauth-cfg
+type: Opaque
+stringData: {{ include "secret" (index $secrets "oauth-cfg") }}
+---
+{{- end }}
+{{- if (index $secrets "oci-registry") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-factory-oci-registry
+type: Opaque
+stringData: {{ include "secret" (index $secrets "oci-registry") }}
+---
+{{- end }}
+{{- if (index $secrets "signing-cfg") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-factory-signing-cfg
+type: Opaque
+stringData: {{ include "secret" (index $secrets "signing-cfg") }}
+---
+{{- end }}
+{{- end }}

--- a/charts/delivery-service/templates/service-deployment.yaml
+++ b/charts/delivery-service/templates/service-deployment.yaml
@@ -57,6 +57,20 @@ spec:
           {{- end }}
           {{- end }}
           volumeMounts:
+            - name: bdba
+              mountPath: /secrets/bdba
+            - name: delivery-db
+              mountPath: /secrets/delivery-db
+            - name: github
+              mountPath: /secrets/github
+            - name: kubernetes
+              mountPath: /secrets/kubernetes
+            - name: oauth-cfg
+              mountPath: /secrets/oauth-cfg
+            - name: oci-registry
+              mountPath: /secrets/oci-registry
+            - name: signing-cfg
+              mountPath: /secrets/signing-cfg
             - name: cfg-factory
               mountPath: "/cfg_factory"
             - name: features-cfg
@@ -72,6 +86,34 @@ spec:
               memory: 5Gi
               cpu: 500m
       volumes:
+        - name: bdba
+          secret:
+            secretName: secret-factory-bdba
+            optional: true # bdba extension is optional
+        - name: delivery-db
+          secret:
+            secretName: secret-factory-delivery-db
+            optional: true # TODO: only optional until cfg factory support has been removed
+        - name: github
+          secret:
+            secretName: secret-factory-github
+            optional: true # TODO: only optional until cfg factory support has been removed
+        - name: kubernetes
+          secret:
+            secretName: secret-factory-kubernetes
+            optional: true # extensions in general are optional
+        - name: oauth-cfg
+          secret:
+            secretName: secret-factory-oauth-cfg
+            optional: true # authentication is optional
+        - name: oci-registry
+          secret:
+            secretName: secret-factory-oci-registry
+            optional: true # TODO: only optional until cfg factory support has been removed
+        - name: signing-cfg
+          secret:
+            secretName: secret-factory-signing-cfg
+            optional: true # authentication is optional
         - name: cfg-factory
           secret:
             secretName: cfg-factory-secret

--- a/charts/extensions/charts/artefact-enumerator/templates/artefact-enumerator.yaml
+++ b/charts/extensions/charts/artefact-enumerator/templates/artefact-enumerator.yaml
@@ -30,6 +30,12 @@ spec:
             {{- end }}
             {{- end }}
             volumeMounts:
+            - name: github
+              mountPath: /secrets/github
+            - name: kubernetes
+              mountPath: /secrets/kubernetes
+            - name: oci-registry
+              mountPath: /secrets/oci-registry
             - name: cfg-factory
               mountPath: "/cfg_factory"
               readOnly: true
@@ -44,6 +50,18 @@ spec:
                 memory: 300Mi
                 cpu: 1000m
           volumes:
+            - name: github
+              secret:
+                secretName: secret-factory-github
+                optional: true # TODO: only optional until cfg factory support has been removed
+            - name: kubernetes
+              secret:
+                secretName: secret-factory-kubernetes
+                optional: true # might use incluster config
+            - name: oci-registry
+              secret:
+                secretName: secret-factory-oci-registry
+                optional: true # TODO: only optional until cfg factory support has been removed
             - name: cfg-factory
               secret:
                 secretName: cfg-factory-secret

--- a/charts/extensions/charts/backlog-controller/templates/backlog-controller.yaml
+++ b/charts/extensions/charts/backlog-controller/templates/backlog-controller.yaml
@@ -28,6 +28,8 @@ spec:
           {{- end }}
           {{- end }}
           volumeMounts:
+          - name: kubernetes
+            mountPath: /secrets/kubernetes
           - name: cfg-factory
             mountPath: "/cfg_factory"
             readOnly: true
@@ -39,6 +41,10 @@ spec:
               memory: 300Mi
               cpu: 300m
       volumes:
+        - name: kubernetes
+          secret:
+            secretName: secret-factory-kubernetes
+            optional: true # might use incluster config
         - name: cfg-factory
           secret:
             secretName: cfg-factory-secret

--- a/charts/extensions/charts/backlog-controller/templates/bdba.yaml
+++ b/charts/extensions/charts/backlog-controller/templates/bdba.yaml
@@ -43,6 +43,16 @@ spec:
           {{- end }}
           {{- end }}
           volumeMounts:
+          - name: aws
+            mountPath: /secrets/aws
+          - name: bdba
+            mountPath: /secrets/bdba
+          - name: github
+            mountPath: /secrets/github
+          - name: kubernetes
+            mountPath: /secrets/kubernetes
+          - name: oci-registry
+            mountPath: /secrets/oci-registry
           - name: cfg-factory
             mountPath: "/cfg_factory"
             readOnly: true
@@ -63,6 +73,26 @@ spec:
               memory: 600Mi
               cpu: 200m
       volumes:
+        - name: aws
+          secret:
+            secretName: secret-factory-aws
+            optional: true # aws client is optional
+        - name: bdba
+          secret:
+            secretName: secret-factory-bdba
+            optional: true # TODO: only optional until cfg factory support has been removed
+        - name: github
+          secret:
+            secretName: secret-factory-github
+            optional: true # TODO: only optional until cfg factory support has been removed
+        - name: kubernetes
+          secret:
+            secretName: secret-factory-kubernetes
+            optional: true # might use incluster config
+        - name: oci-registry
+          secret:
+            secretName: secret-factory-oci-registry
+            optional: true # TODO: only optional until cfg factory support has been removed
         - name: cfg-factory
           secret:
             secretName: cfg-factory-secret

--- a/charts/extensions/charts/backlog-controller/templates/clamav.yaml
+++ b/charts/extensions/charts/backlog-controller/templates/clamav.yaml
@@ -39,6 +39,14 @@ spec:
           {{- end }}
           {{- end }}
           volumeMounts:
+          - name: aws
+            mountPath: /secrets/aws
+          - name: github
+            mountPath: /secrets/github
+          - name: kubernetes
+            mountPath: /secrets/kubernetes
+          - name: oci-registry
+            mountPath: /secrets/oci-registry
           - name: cfg-factory
             mountPath: "/cfg_factory"
             readOnly: true
@@ -62,6 +70,22 @@ spec:
               memory: 8Gi
               cpu: 2000m
       volumes:
+        - name: aws
+          secret:
+            secretName: secret-factory-aws
+            optional: true # aws client is optional
+        - name: github
+          secret:
+            secretName: secret-factory-github
+            optional: true # TODO: only optional until cfg factory support has been removed
+        - name: kubernetes
+          secret:
+            secretName: secret-factory-kubernetes
+            optional: true # might use incluster config
+        - name: oci-registry
+          secret:
+            secretName: secret-factory-oci-registry
+            optional: true # TODO: only optional until cfg factory support has been removed
         - name: cfg-factory
           secret:
             secretName: cfg-factory-secret

--- a/charts/extensions/charts/backlog-controller/templates/issue-replicator.yaml
+++ b/charts/extensions/charts/backlog-controller/templates/issue-replicator.yaml
@@ -36,6 +36,12 @@ spec:
           {{- end }}
           {{- end }}
           volumeMounts:
+          - name: github
+            mountPath: /secrets/github
+          - name: kubernetes
+            mountPath: /secrets/kubernetes
+          - name: oci-registry
+            mountPath: /secrets/oci-registry
           - name: cfg-factory
             mountPath: "/cfg_factory"
             readOnly: true
@@ -56,6 +62,18 @@ spec:
               memory: 600Mi
               cpu: 1000m
       volumes:
+        - name: github
+          secret:
+            secretName: secret-factory-github
+            optional: true # TODO: only optional until cfg factory support has been removed
+        - name: kubernetes
+          secret:
+            secretName: secret-factory-kubernetes
+            optional: true # might use incluster config
+        - name: oci-registry
+          secret:
+            secretName: secret-factory-oci-registry
+            optional: true # TODO: only optional until cfg factory support has been removed
         - name: cfg-factory
           secret:
             secretName: cfg-factory-secret

--- a/charts/extensions/charts/cache-manager/templates/cache-manager.yaml
+++ b/charts/extensions/charts/cache-manager/templates/cache-manager.yaml
@@ -35,6 +35,12 @@ spec:
               value: {{ $value }}
             {{- end }}
             volumeMounts:
+            - name: delivery-db
+              mountPath: /secrets/delivery-db
+            - name: kubernetes
+              mountPath: /secrets/kubernetes
+            - name: oci-registry
+              mountPath: /secrets/oci-registry
             - name: cfg-factory
               mountPath: "/cfg_factory"
               readOnly: true
@@ -42,6 +48,18 @@ spec:
               mountPath: "/features_cfg"
               readOnly: true
           volumes:
+            - name: delivery-db
+              secret:
+                secretName: secret-factory-delivery-db
+                optional: true # TODO: only optional until cfg factory support has been removed
+            - name: kubernetes
+              secret:
+                secretName: secret-factory-kubernetes
+                optional: true # extensions in general are optional
+            - name: oci-registry
+              secret:
+                secretName: secret-factory-oci-registry
+                optional: true # TODO: only optional until cfg factory support has been removed
             - name: cfg-factory
               secret:
                 secretName: cfg-factory-secret

--- a/charts/extensions/charts/delivery-db-backup/templates/delivery-db-backup.yaml
+++ b/charts/extensions/charts/delivery-db-backup/templates/delivery-db-backup.yaml
@@ -34,10 +34,34 @@ spec:
               value: {{ $value.K8S_CFG_NAME }}
             {{- end }}
             volumeMounts:
+            - name: delivery-db
+              mountPath: /secrets/delivery-db
+            - name: github
+              mountPath: /secrets/github
+            - name: kubernetes
+              mountPath: /secrets/kubernetes
+            - name: oci-registry
+              mountPath: /secrets/oci-registry
             - name: cfg-factory
               mountPath: "/cfg_factory"
               readOnly: true
           volumes:
+            - name: delivery-db
+              secret:
+                secretName: secret-factory-delivery-db
+                optional: true # TODO: only optional until cfg factory support has been removed
+            - name: github
+              secret:
+                secretName: secret-factory-github
+                optional: true # TODO: only optional until cfg factory support has been removed
+            - name: kubernetes
+              secret:
+                secretName: secret-factory-kubernetes
+                optional: true # extensions in general are optional
+            - name: oci-registry
+              secret:
+                secretName: secret-factory-oci-registry
+                optional: true # TODO: only optional until cfg factory support has been removed
             - name: cfg-factory
               secret:
                 secretName: cfg-factory-secret


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Added `bootstrapping` chart which allows installation of required secrets
```
```noteworthy operator
Added (for-now-)optional volume mounts for secrets installed by `bootstrapping` chart (replaces `cfg-factory-secret`)
```
