### PR TITLE
Stop re-applying existing BDBA triages to new BDBA apps

### DIFF
--- a/bdba/__main__.py
+++ b/bdba/__main__.py
@@ -139,9 +139,8 @@ def scan(
     )
 
     processor = bdba.scanning.ResourceGroupProcessor(
-        group_id=bdba_config.group_id,
-        reference_group_ids=bdba_config.reference_group_ids,
         bdba_client=bdba_client,
+        group_id=bdba_config.group_id,
     )
 
     access = resource_node.resource.access
@@ -189,8 +188,6 @@ def scan(
         license_cfg=bdba_config.license_cfg,
         cve_rescoring_ruleset=bdba_config.cve_rescoring_ruleset,
         auto_assess_max_severity=bdba_config.auto_assess_max_severity,
-        use_product_cache=False,
-        delete_inactive_products_after_seconds=bdba_config.delete_inactive_products_after_seconds,
     )
 
     if bdba_config.blacklist_finding_types:

--- a/charts/extensions/crds/scan-configuration.yaml
+++ b/charts/extensions/crds/scan-configuration.yaml
@@ -168,10 +168,6 @@ spec:
                       type: string
                     group_id:
                       type: integer
-                    reference_group_ids:
-                      type: array
-                      items:
-                        type: integer
                     cvss_version:
                       type: string
                     aws_cfg_name:
@@ -204,8 +200,6 @@ spec:
                                   type: string
                     auto_assess_max_severity:
                       type: string
-                    delete_inactive_products_after_seconds:
-                      type: integer
                 issue_replicator:
                   x-kubernetes-preserve-unknown-fields: true
                   type: object

--- a/cli/_bdba.py
+++ b/cli/_bdba.py
@@ -264,9 +264,8 @@ def scan(
                 resource_node=resource_node,
             )
             processor = bdba.scanning.ResourceGroupProcessor(
-                group_id=bdba_group_id,
-                reference_group_ids=reference_bdba_group_ids,
                 bdba_client=bdba_client,
+                group_id=bdba_group_id,
             )
 
             access = resource_node.resource.access

--- a/config.py
+++ b/config.py
@@ -184,8 +184,6 @@ class BDBAConfig:
         name of config element to use for bdba scanning
     :param int group_id:
         bdba group id to use for scanning
-    :param tuple[int] reference_group_ids:
-        bdba group ids to consider when copying existing assessments
     :param CVSSVersion cvss_version
     :param str aws_cfg_name
         cfg-element used to create s3 client to retrieve artefacts
@@ -201,8 +199,6 @@ class BDBAConfig:
         only findings below this severity will be auto-rescored
     :param LicenseCfg license_cfg:
         required to differentiate between allowed and prohibited licenses
-    :param int delete_inactive_products_after_seconds:
-        time after which a bdba product is deleted if the scanned artefact is not active anymore
     :param set[str] blacklist_finding_types:
         finding types which are provided by BDBA but should _not_ be populated into the delivery-db
     '''
@@ -211,7 +207,6 @@ class BDBAConfig:
     lookup_new_backlog_item_interval: int
     cfg_name: str
     group_id: int
-    reference_group_ids: tuple[int]
     cvss_version: bdba.model.CVSSVersion
     aws_cfg_name: str | None
     processing_mode: bdba.model.ProcessingMode
@@ -220,7 +215,6 @@ class BDBAConfig:
     cve_rescoring_ruleset: rescore.model.CveRescoringRuleSet | None
     auto_assess_max_severity: dso.cvss.CVESeverity
     license_cfg: LicenseCfg
-    delete_inactive_products_after_seconds: int
     blacklist_finding_types: set[str]
 
 
@@ -640,12 +634,6 @@ def deserialise_bdba_config(
         property_key='group_id',
     )
 
-    reference_group_ids = tuple(deserialise_config_property(
-        config=bdba_config,
-        property_key='referenceGroupIds',
-        default_value=[],
-    ))
-
     cvss_version_raw = deserialise_config_property(
         config=bdba_config,
         property_key='cvss_version',
@@ -737,14 +725,6 @@ def deserialise_bdba_config(
     )
     license_cfg = LicenseCfg(prohibited_licenses=prohibited_licenses)
 
-    delete_inactive_products_after_seconds = deserialise_config_property(
-        config=bdba_config,
-        property_key='delete_inactive_products_after_seconds',
-        default_value=None,
-        absent_ok=True,
-        on_absent_message='inactive bdba products will not be deleted',
-    )
-
     blacklist_finding_types = deserialise_config_property(
         config=bdba_config,
         property_key='blacklist_finding_types',
@@ -767,7 +747,6 @@ def deserialise_bdba_config(
         lookup_new_backlog_item_interval=lookup_new_backlog_item_interval,
         cfg_name=cfg_name,
         group_id=group_id,
-        reference_group_ids=reference_group_ids,
         cvss_version=cvss_version,
         aws_cfg_name=aws_cfg_name,
         processing_mode=processing_mode,
@@ -776,7 +755,6 @@ def deserialise_bdba_config(
         cve_rescoring_ruleset=default_rule_set,
         auto_assess_max_severity=auto_assess_max_severity,
         license_cfg=license_cfg,
-        delete_inactive_products_after_seconds=delete_inactive_products_after_seconds,
         blacklist_finding_types=blacklist_finding_types,
     )
 

--- a/local-setup/kind/cluster/values-extensions.yaml
+++ b/local-setup/kind/cluster/values-extensions.yaml
@@ -148,7 +148,6 @@ configuration:
         #     - OSL
         #     - RPL-1.5
         #     - sleepycat
-        #   delete_inactive_products_after_seconds: 1209600 # 2 weeks
 
         # clamav:
         #   delivery_service_url: http://delivery-service.delivery.svc.cluster.local:8080


### PR DESCRIPTION
**What this PR does / why we need it**:
As of now, BDBA triages are stored as rescorings in the delivery-db using the `SINGLE` scope, i.e. they are not re-used across new artefact versions. With this change, the scope is extended to `ARTEFACT`, so they will be also applied to new versions, however, not among different artefact extra ids (this is different to now!).

With that, we no longer have to also re-apply existing BDBA triages to new BDBA apps, as we use the rescorings in the delivery-db as single sourth of truth anyways (the BDBA UI may show findings already which actually don't have to be assessed anymore because they were already assessed using the delivery-dashboard).

This also elimnates the requirement to delete old BDBA apps, as it was required as an optimisation to have less apps from where to import triages. Since we don't retrieve every existing app result anymore, this isn't a limitation anymore.

With this change, the BDBA config properties `reference_group_ids` and `delete_inactive_products_after_seconds` are not required anymore and thus removed from the scan configuration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
BDBA triages are no longer being replicated to new BDBA apps -> only Delivery-Dashboard shows actually unassessed findings
```
```noteworthy user
new BDBA triages are no longer being shared across different artefact extra identities -> use `COMPONENT` scope instead
```
```noteworthy operator
BDBA cfg properties `reference_group_ids` and `delete_inactive_products_after_seconds` have been removed
```