### PR TITLE
Remove misleading `0 targets` in diki issues template

### DIFF
--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -684,25 +684,26 @@ def _diki_template_vars(
                 # process merged checks
                 case dict():
                     for key, value in check.targets.items():
-                        if value is None:
-                            shortened_summary += f'{key}: 0 targets\n'
-                            summary += f'{key}: 0 targets\n'
+                        if value is None or len(value) == 0:
+                            shortened_summary += f'**{key}**\n'
+                            summary += f'**{key}**\n'
                             continue
-                        shortened_summary += f'{key}: {len(value)} targets\n'
+                        shortened_summary += f'**{key}**: {len(value)} targets\n'
                         summary += '<details>\n'
                         summary += f'<summary>{key}:</summary>\n\n'
                         summary += _targets_table(value)
                         summary += '</details>\n\n'
                 # process single checks
                 case list():
-                    shortened_summary += f'{len(check.targets)} targets\n'
                     if len(check.targets) == 0:
-                        summary += '0 targets\n'
+                        shortened_summary += 'n/a\n'
+                        summary += 'n/a\n'
                     else:
+                        shortened_summary += f'{len(check.targets)} targets\n'
                         summary += _targets_table(check.targets)
                 case None:
-                    shortened_summary += '0 targets\n'
-                    summary += '0 targets\n'
+                    shortened_summary += 'n/a\n'
+                    summary += 'n/a\n'
                 case _:
                     raise TypeError(check.targets) # this line should never be reached
 

--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -692,7 +692,7 @@ def _diki_template_vars(
                             summary += '</details>\n\n'
                         else:
                             shortened_summary += f'**{key}**\n'
-                            summary += f'**{key}**\n'              
+                            summary += f'**{key}**\n'
                 # process single checks
                 case list():
                     if len(check.targets) == 0:

--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -684,15 +684,15 @@ def _diki_template_vars(
                 # process merged checks
                 case dict():
                     for key, value in check.targets.items():
-                        if value is None or len(value) == 0:
+                        if value:
+                            shortened_summary += f'**{key}**: {len(value)} targets\n'
+                            summary += '<details>\n'
+                            summary += f'<summary>{key}:</summary>\n\n'
+                            summary += _targets_table(value)
+                            summary += '</details>\n\n'
+                        else:
                             shortened_summary += f'**{key}**\n'
-                            summary += f'**{key}**\n'
-                            continue
-                        shortened_summary += f'**{key}**: {len(value)} targets\n'
-                        summary += '<details>\n'
-                        summary += f'<summary>{key}:</summary>\n\n'
-                        summary += _targets_table(value)
-                        summary += '</details>\n\n'
+                            summary += f'**{key}**\n'              
                 # process single checks
                 case list():
                     if len(check.targets) == 0:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
