### PR TITLE
Add refactored scan cfg and new finding-specific model classes

### DIFF
--- a/odg/defaults.yaml
+++ b/odg/defaults.yaml
@@ -1,0 +1,109 @@
+categorisations:
+  - type: finding/vulnerability
+    gardener:
+      - name: NONE
+        value: 0
+      - name: LOW
+        value: 1
+        allowed_processing_time: 120
+        automatic_rescoring: True
+        exclude_from_reporting: True
+        selector:
+          cve_score_range:
+            min: 0.0
+            max: 3.9
+      - name: MEDIUM
+        value: 2
+        allowed_processing_time: 90
+        automatic_rescoring: True
+        selector:
+          cve_score_range:
+            min: 4.0
+            max: 6.9
+      - name: HIGH
+        value: 4
+        allowed_processing_time: 30
+        selector:
+          cve_score_range:
+            min: 7.0
+            max: 8.9
+      - name: CRITICAL
+        value: 8
+        allowed_processing_time: 30
+        selector:
+          cve_score_range:
+            min: 9.0
+            max: 10.0
+
+rescoring_rulesets:
+  - type: finding/vulnerability
+    gardener:
+      name: vulnerability-rescoring-v1
+      rules:
+        - category_value: network_exposure:public
+          name: network-exposure-public
+          rules:
+            - cve_values:
+                - AV:N
+              rescore: no-change
+            - cve_values:
+                - AV:A
+              rescore: reduce
+            - cve_values:
+                - AV:L
+                - AV:P
+              rescore: not-exploitable
+        - category_value: network_exposure:protected
+          name: network-exposure-protected
+          rules:
+            - cve_values:
+                - AV:N
+              rescore: reduce
+            - cve_values:
+                - AV:A
+                - AV:L
+                - AV:P
+              rescore: not-exploitable
+        - category_value: network_exposure:private
+          name: network-exposure-private
+          rules:
+            - cve_values:
+                - AV:N
+                - AV:A
+                - AV:L
+                - AV:P
+              rescore: not-exploitable
+        - category_value: authentication_enforced:true
+          name: authentication-enforced
+          rules:
+            - cve_values:
+                - PR:L
+                - PR:H
+              rescore: reduce
+        - category_value: user_interaction:gardener-operator
+          name: user-interaction-gardener-operator
+          rules:
+            - cve_values:
+                - UI:R
+              rescore: reduce
+        - category_value: confidentiality_requirement:none
+          name: confidentiality-requirement-none
+          rules:
+            - cve_values:
+                - C:H
+                - C:L
+              rescore: reduce
+        - category_value: integrity_requirement:none
+          name: integrity-requirement-none
+          rules:
+            - cve_values:
+                - I:H
+                - I:L
+              rescore: reduce
+        - category_value: availability_requirement:none
+          name: availability-requirement-none
+          rules:
+            - cve_values:
+                - A:H
+                - A:L
+              rescore: reduce

--- a/odg/findings.py
+++ b/odg/findings.py
@@ -1,0 +1,508 @@
+import dataclasses
+import enum
+import os
+import re
+import typing
+
+import dacite
+import yaml
+
+import dso.model
+
+import rescore.model as rm
+
+
+own_dir = os.path.abspath(os.path.dirname(__file__))
+defaults_file_path = os.path.join(own_dir, 'defaults.yaml')
+
+
+class ModelValidationError(ValueError):
+    pass
+
+
+class FindingType(enum.StrEnum):
+    CRYPTO = 'finding/crypto'
+    DIKI = 'finding/diki'
+    LICENSE = 'finding/license'
+    MALWARE = 'finding/malware'
+    SAST = 'finding/sast'
+    VULNERABILITY = 'finding/vulnerability'
+
+
+@dataclasses.dataclass
+class MinMaxRange:
+    min: float
+    max: float
+
+
+@dataclasses.dataclass
+class LicenseFindingSelector:
+    '''
+    :param list[str] license_names:
+        List of regexes to determine matching licenses.
+    '''
+    license_names: list[str]
+
+
+@dataclasses.dataclass
+class MalwareFindingSelector:
+    '''
+    :param list[str] malware_names:
+        List of regexes to determine matching malware.
+    '''
+    malware_names: list[str]
+
+
+@dataclasses.dataclass
+class SASTFindingSelector:
+    '''
+    :param list[str] sub_types:
+        List of regexes to determine matching missing linter findings.
+    '''
+    sub_types: list[str]
+
+
+@dataclasses.dataclass
+class VulnerabilityFindingSelector:
+    '''
+    :param MinMaxRange cve_score_range:
+        Min (including) and max (including) cve score to determine matching CVEs.
+    '''
+    cve_score_range: MinMaxRange
+
+
+@dataclasses.dataclass
+class FindingCategorisation:
+    '''
+    :param str name:
+        Human-friendly name of the category (will be displayed to the user).
+    :param int value:
+        Finding type independent scala to determine the actual severity of the category, e.g. to
+        be able to sort by severity or to determine appropriate colours. Only values between 0 and
+        100 are allowed. Note: There must be exactly one category per finding which defines value as
+        0 to express that a finding is not relevant anymore.
+    :param int allowed_processing_time:
+        The days after which a finding must have been assessed at the latest.
+    :param Selector selector:
+        Used to determine findings which should be assigned to this category.
+    :param bool automatic_rescoring:
+        If set and a rescoring ruleset is available, findings of this category are automatically
+        rescored according to the configured ruleset.
+    :param bool exclude_from_reporting:
+        If set, findings belonging to this category won't be included in reportings, such as the
+        GitHub issues or in the Delivery-Dashboard compliance summary chips.
+    '''
+    name: str
+    value: int
+    allowed_processing_time: int | None
+    selector: (
+        LicenseFindingSelector
+        | MalwareFindingSelector
+        | SASTFindingSelector
+        | VulnerabilityFindingSelector
+        | None
+    )
+    automatic_rescoring: bool = False
+    exclude_from_reporting: bool = False
+
+
+@dataclasses.dataclass
+class FindingIssues:
+    '''
+    :param str template:
+        Template to use for the created GitHub issues. See `issue_replicator.github` for available
+        substitues.
+    :param bool enable_issues:
+        If disabled, no GitHub issues will be created/updated for the specified finding type.
+    :param bool enable_assignees:
+        If set, determined responsibles will be automatically assigned to their respective issues.
+    :param bool enable_per_finding:
+        If set, GitHub issues will be created per finding for a specific artefact as opposed to a
+        single issue with all findings.
+    '''
+    template: str = '{summary}'
+    enable_issues: bool = True
+    enable_assignees: bool = True
+    enable_per_finding: bool = False
+
+
+class FindingFilterSemantics(enum.StrEnum):
+    INCLUDE = 'include'
+    EXCLUDE = 'exclude'
+
+
+@dataclasses.dataclass
+class FindingFilter:
+    '''
+    The filter can be used to stop detection of the specified findings for certain components. If
+    only "include" filters are configured, all other components will be ignored. If only "exclude"
+    filters are configured, all other components will be considered. If a combination of "include"
+    and "exclude" filters is configured, all included components which are not specifically excluded
+    as well will be considered.
+
+    Note: All properties, except `artefact_kind` and `artefact_extra_id`, will be compared as
+    regexes. The `name` parameter is only used for informational purposes, such as logging.
+    '''
+    semantics: FindingFilterSemantics
+    name: str | None
+    component_name: list[str] | str | None
+    component_version: list[str] | str | None
+    artefact_kind: list[dso.model.ArtefactKind] | dso.model.ArtefactKind | None
+    artefact_name: list[str] | str | None
+    artefact_version: list[str] | str | None
+    artefact_type: list[str] | str | None
+    artefact_extra_id: list[dict] | dict | None
+
+    def __post_init__(self):
+        if isinstance(self.component_name, str):
+            self.component_name = [self.component_name]
+        if isinstance(self.component_version, str):
+            self.component_version = [self.component_version]
+        if isinstance(self.artefact_kind, dso.model.ArtefactKind):
+            self.artefact_kind = [self.artefact_kind]
+        if isinstance(self.artefact_name, str):
+            self.artefact_name = [self.artefact_name]
+        if isinstance(self.artefact_version, str):
+            self.artefact_version = [self.artefact_version]
+        if isinstance(self.artefact_type, str):
+            self.artefact_type = [self.artefact_type]
+        if isinstance(self.artefact_extra_id, dict):
+            self.artefact_extra_id = [self.artefact_extra_id]
+
+        self.artefact_extra_id = [
+            dso.model.normalise_artefact_extra_id(artefact_extra_id)
+            for artefact_extra_id in self.artefact_extra_id or []
+        ]
+
+    def matches(self, artefact: dso.model.ComponentArtefactId) -> bool:
+        def match_regexes(patterns: list[str], string: str) -> bool:
+            if not patterns:
+                return True
+            return any(re.fullmatch(pattern, string, re.IGNORECASE) for pattern in patterns)
+
+        if not match_regexes(self.component_name, artefact.component_name):
+            return False
+        if not match_regexes(self.component_version, artefact.component_version):
+            return False
+        if self.artefact_kind and artefact.artefact_kind not in self.artefact_kind:
+            return False
+        if not match_regexes(self.artefact_name, artefact.artefact.artefact_name):
+            return False
+        if not match_regexes(self.artefact_version, artefact.artefact.artefact_version):
+            return False
+        if not match_regexes(self.artefact_type, artefact.artefact.artefact_type):
+            return False
+        if (
+            self.artefact_extra_id
+            and artefact.artefact.normalised_artefact_extra_id not in self.artefact_extra_id
+        ):
+            return False
+
+        return True
+
+
+@dataclasses.dataclass
+class Finding:
+    '''
+    :param FindingType type
+    :param list[FindingCategorisation] categorisation:
+        The available categories for this type of findings and information on how to assign the
+        findings to one of these categories. If a string is given, the corresponding standard
+        categorisations are automatically set after instantiation of this class.
+    :param list[FindingFilter] filter:
+        An optional filter to restrict detection of findings to certain artefacts.
+    :param RuleSet ruleset:
+        Based on the finding type, there might be a ruleset available to automatically suggest/do
+        rescorings. If a string is given, the corresponding standard ruleset is automatically set
+        after instantiation of this class.
+    :param FindingIssues issues:
+        Configuration whether and if yes, how, GitHub tracking issues should be created/updated.
+    '''
+    type: FindingType
+    categorisations: list[FindingCategorisation] | str
+    filter: list[FindingFilter] | None
+    rescoring_ruleset: dict | str | None
+    issues: FindingIssues = dataclasses.field(default_factory=FindingIssues)
+
+    @staticmethod
+    def from_dict(
+        findings_raw: list[dict],
+        finding_type: FindingType | None=None,
+    ) -> list[typing.Self] | typing.Self | None:
+        if not finding_type:
+            return [
+                dacite.from_dict(
+                    data_class=Finding,
+                    data=finding_raw,
+                    config=dacite.Config(
+                        cast=[enum.Enum],
+                    ),
+                ) for finding_raw in findings_raw
+            ]
+
+        for finding_raw in findings_raw:
+            if FindingType(finding_raw['type']) is finding_type:
+                break
+        else:
+            return None
+
+        return dacite.from_dict(
+            data_class=Finding,
+            data=finding_raw,
+            config=dacite.Config(
+                cast=[enum.Enum],
+            ),
+        )
+
+    @staticmethod
+    def from_file(
+        path: str,
+        finding_type: FindingType | None=None,
+    ) -> list[typing.Self] | typing.Self | None:
+        with open(path) as file:
+            findings_raw = yaml.safe_load(file).get('findings', [])
+
+        return Finding.from_dict(
+            findings_raw=findings_raw,
+            finding_type=finding_type,
+        )
+
+    def __post_init__(self):
+        if isinstance(self.categorisations, str):
+            self.categorisations = default_finding_categorisations(
+                finding_type=self.type,
+                name=self.categorisations,
+            )
+
+        if isinstance(self.rescoring_ruleset, str):
+            self.rescoring_ruleset = default_rescoring_ruleset(
+                finding_type=self.type,
+                name=self.rescoring_ruleset,
+            )
+
+        if isinstance(self.rescoring_ruleset, dict):
+            if self.type is FindingType.SAST:
+                self.rescoring_ruleset = rm.SastRescoringRuleSet( # noqa: E1123
+                    name=self.rescoring_ruleset['name'],
+                    rules=list(
+                        rm.sast_rescoring_rules_from_dict(self.rescoring_ruleset['rules'])
+                    ),
+                    description=self.rescoring_ruleset.get('description'),
+                )
+
+            elif self.type is FindingType.VULNERABILITY:
+                self.rescoring_ruleset = rm.CveRescoringRuleSet( # noqa: E1123
+                    name=self.rescoring_ruleset['name'],
+                    rules=list(
+                        rm.cve_rescoring_rules_from_dicts(self.rescoring_ruleset['rules'])
+                    ),
+                    description=self.rescoring_ruleset.get('description'),
+                )
+
+        self._validate()
+
+    def _validate(self):
+        match self.type:
+            case FindingType.DIKI:
+                self._validate_diki()
+            case FindingType.LICENSE:
+                self._validate_license()
+            case FindingType.MALWARE:
+                self._validate_malware()
+            case FindingType.SAST:
+                self._validate_sast()
+            case FindingType.VULNERABILITY:
+                self._validate_vulnerabilty()
+            case _:
+                pass
+
+    def _validate_diki(self):
+        violations = []
+
+        for categorisation in self.categorisations:
+            if categorisation.selector:
+                violations.append(
+                    'selectors are not supported by diki, the diki extension takes care of '
+                    'categorisation itself'
+                )
+
+        if not self.none_categorisation:
+            violations.append(
+                'there must be exactly one categorisation with "value=0" to express that a finding '
+                'is not relevant anymore'
+            )
+
+        if not violations:
+            return
+
+        e = ModelValidationError('diki finding model violations found:')
+        e.add_note('\n'.join(violations))
+        raise e
+
+    def _validate_license(self):
+        violations = []
+
+        for categorisation in self.categorisations:
+            selector = categorisation.selector
+            if selector and not isinstance(selector, LicenseFindingSelector):
+                violations.append(f'selector must be of type {LicenseFindingSelector}')
+
+        if not self.none_categorisation:
+            violations.append(
+                'there must be exactly one categorisation with "value=0" to express that a finding '
+                'is not relevant anymore'
+            )
+
+        if not violations:
+            return
+
+        e = ModelValidationError('license finding model violations found:')
+        e.add_note('\n'.join(violations))
+        raise e
+
+    def _validate_malware(self):
+        violations = []
+
+        for categorisation in self.categorisations:
+            selector = categorisation.selector
+            if selector and not isinstance(selector, MalwareFindingSelector):
+                violations.append(f'selector must be of type {MalwareFindingSelector}')
+
+        if not self.none_categorisation:
+            violations.append(
+                'there must be exactly one categorisation with "value=0" to express that a finding '
+                'is not relevant anymore'
+            )
+
+        if not violations:
+            return
+
+        e = ModelValidationError('malware finding model violations found:')
+        e.add_note('\n'.join(violations))
+        raise e
+
+    def _validate_sast(self):
+        violations = []
+
+        for categorisation in self.categorisations:
+            selector = categorisation.selector
+            if selector and not isinstance(selector, SASTFindingSelector):
+                violations.append(f'selector must be of type {SASTFindingSelector}')
+
+        if not self.none_categorisation:
+            violations.append(
+                'there must be exactly one categorisation with "value=0" to express that a finding '
+                'is not relevant anymore'
+            )
+
+        if (
+            self.rescoring_ruleset
+            and not isinstance(self.rescoring_ruleset, rm.SastRescoringRuleSet)
+        ):
+            violations.append(f'rescoring rule set must be of type {rm.SastRescoringRuleSet}')
+
+        if not violations:
+            return
+
+        e = ModelValidationError('sast finding model violations found:')
+        e.add_note('\n'.join(violations))
+        raise e
+
+    def _validate_vulnerabilty(self):
+        violations = []
+
+        for categorisation in self.categorisations:
+            selector = categorisation.selector
+            if selector and not isinstance(selector, VulnerabilityFindingSelector):
+                violations.append(f'selector must be of type {VulnerabilityFindingSelector}')
+
+        if not self.none_categorisation:
+            violations.append(
+                'there must be exactly one categorisation with "value=0" to express that a finding '
+                'is not relevant anymore'
+            )
+
+        if (
+            self.rescoring_ruleset
+            and not isinstance(self.rescoring_ruleset, rm.CveRescoringRuleSet)
+        ):
+            violations.append(f'rescoring rule set must be of type {rm.CveRescoringRuleSet}')
+
+        if not violations:
+            return
+
+        e = ModelValidationError('vulnerability finding model violations found:')
+        e.add_note('\n'.join(violations))
+        raise e
+
+    @property
+    def none_categorisation(self) -> FindingCategorisation | None:
+        '''
+        Returns the category which marks a finding as "not relevant anymore", e.g. if it is assessed
+        as a false-positive.
+        '''
+        for categorisation in self.categorisations:
+            if categorisation.value == 0:
+                return categorisation
+
+    def matches(self, artefact: dso.model.ComponentArtefactId) -> bool:
+        if not self.filter:
+            return True
+
+        # we need to check whether there is at least one "include" filter because if there is none,
+        # all not explicitly excluded artefacts are automatically included
+        is_include_filter = FindingFilterSemantics.INCLUDE in (f.semantics for f in self.filter)
+
+        is_included = False
+        is_excluded = False
+
+        for filter in self.filter:
+            if filter.semantics is FindingFilterSemantics.INCLUDE and filter.matches(artefact):
+                is_included = True
+            elif filter.semantics is FindingFilterSemantics.EXCLUDE and filter.matches(artefact):
+                is_excluded = True
+
+        return not is_excluded and (not is_include_filter or is_included)
+
+
+def default_finding_categorisations(
+    finding_type: FindingType,
+    name: str,
+) -> list[FindingCategorisation]:
+    with open(defaults_file_path) as file:
+        categorisations_raw = yaml.safe_load(file).get('categorisations', [])
+
+    for categorisation_raw in categorisations_raw:
+        if FindingType(categorisation_raw['type']) is finding_type:
+            break
+    else:
+        raise ValueError(f'did not find default categorisation for {finding_type=}')
+
+    if not name in categorisation_raw:
+        raise ValueError(f'did not find default categorisation for {finding_type=} and {name=}')
+
+    return [
+        dacite.from_dict(
+            data_class=FindingCategorisation,
+            data=categorisation,
+        ) for categorisation in categorisation_raw[name]
+    ]
+
+
+def default_rescoring_ruleset(
+    finding_type: FindingType,
+    name: str,
+) -> dict:
+    with open(defaults_file_path) as file:
+        rescoring_rulesets_raw = yaml.safe_load(file).get('rescoring_rulesets', [])
+
+    for rescoring_ruleset_raw in rescoring_rulesets_raw:
+        if FindingType(rescoring_ruleset_raw['type']) is finding_type:
+            break
+    else:
+        raise ValueError(f'did not find default rescoring ruleset for {finding_type=}')
+
+    if not name in rescoring_ruleset_raw:
+        raise ValueError(f'did not find default rescoring ruleset for {finding_type=} and {name=}')
+
+    return rescoring_ruleset_raw[name]

--- a/odg/scan_cfg.py
+++ b/odg/scan_cfg.py
@@ -1,0 +1,534 @@
+import dataclasses
+import datetime
+import enum
+import functools
+import logging
+import typing
+
+import dacite
+import github3.repos
+import yaml
+
+import dso.model
+import github.compliance.milestone as gcmi
+import ocm
+
+import bdba.model
+import lookups
+
+
+logger = logging.getLogger(__name__)
+
+
+class Services(enum.StrEnum):
+    ARTEFACT_ENUMERATOR = 'artefactEnumerator'
+    BACKLOG_CONTROLLER = 'backlogController'
+    BDBA = 'bdba'
+    CACHE_MANAGER = 'cacheManager'
+    CLAMAV = 'clamav'
+    DELIVERY_DB_BACKUP = 'deliveryDbBackup'
+    ISSUE_REPLICATOR = 'issueReplicator'
+    SAST_LINT_CHECK = 'sastLintCheck'
+
+
+class VersionAliases(enum.StrEnum):
+    GREATEST = 'greatest'
+
+
+class WarningVerbosities(enum.StrEnum):
+    FAIL = 'fail'
+    IGNORE = 'ignore'
+    WARNING = 'warning'
+
+
+@dataclasses.dataclass
+class BacklogItemMixins:
+    '''
+    Defines properties and functions which are shared among those extensions which determine their
+    workload using the BacklogItem custom resource.
+    '''
+    def is_supported(
+        self,
+        artefact_kind: dso.model.ArtefactKind | None=None,
+        access_type: ocm.AccessType | None=None,
+    ) -> bool:
+        raise NotImplementedError('function must be implemented by derived classes')
+
+
+@dataclasses.dataclass
+class Component:
+    component_name: str
+    version: str | None
+    ocm_repo_url: str | None
+    version_filter: str | None
+    timerange_days: int | None
+    max_versions_limit: int = 1
+
+    def __post_init__(self):
+        # "version=None" will be treated from subsequent functions like "greatest"
+        if self.version == VersionAliases.GREATEST:
+            self.version = None
+
+    @property
+    def ocm_repo(self) -> ocm.OciOcmRepository | None:
+        if not self.ocm_repo_url:
+            return None
+
+        return ocm.OciOcmRepository(
+            baseUrl=self.ocm_repo_url,
+        )
+
+
+@dataclasses.dataclass
+class TimeRange:
+    days_from: int = -90
+    days_to: int = 150
+
+    @property
+    def start_date(self) -> datetime.date:
+        today = datetime.date.today()
+        return today + datetime.timedelta(days=self.days_from)
+
+    @property
+    def end_date(self) -> datetime.date:
+        today = datetime.date.today()
+        return today + datetime.timedelta(days=self.days_to)
+
+
+@dataclasses.dataclass
+class ArtefactEnumeratorConfig:
+    '''
+    :param str delivery_service_url
+    :param list[Component] components:
+        Components which are classified as "active" and for which compliance snapshots are created.
+    :param TimeRange sprints_relative_time_range:
+        Earliest start and latest end date for which compliance snapshots should be created. If not
+        set, all available sprints will be considered.
+    :param int compliance_snapshot_grace_period:
+        Time after which inactive compliance snapshots are deleted from the delivery-db.
+    '''
+    delivery_service_url: str
+    components: list[Component]
+    sprints_relative_time_range: TimeRange | None
+    compliance_snapshot_grace_period: int = 60 * 60 * 24 # 24h
+
+
+@dataclasses.dataclass
+class BacklogControllerConfig:
+    '''
+    :param int max_replicas:
+        Maximum number of replicas per extension to which the backlog controller will scale. Note,
+        that the maximum number for the issue replicator is always 1 to ensure consistent GitHub
+        tracking issues.
+    :param int backlog_items_per_replica
+        Used to calculate the desired number of replicas.
+    :param int remove_claim_after_minutes
+        To prevent backlog items from not being processed in an error case because they are claimed
+        infinetly by a single pod, the backlog controller will remove the claim again after this
+        period.
+    '''
+    max_replicas: int = 5
+    backlog_items_per_replica: int = 3
+    remove_claim_after_minutes: int = 30
+
+
+@dataclasses.dataclass
+class Mapping:
+    prefix: str
+
+
+@dataclasses.dataclass
+class BDBAMapping(Mapping):
+    '''
+    :param int group_id:
+        BDBA group id to use for scanning.
+    :param str bdba_secret_name:
+        Name of the BDBA secret element to use for scanning.
+    :param str aws_secret_name
+        Name of the AWS secret element to use to retrieve artefacts from S3.
+    :param ProcessingMode processing_mode:
+        Defines the scanning behaviour in case there is already an existing scan.
+    :param CVESeverity auto_assess_max_severity:
+        Only findings below or equal to this severity will be auto-rescored.
+    '''
+    group_id: int
+    bdba_secret_name: str
+    aws_secret_name: str | None
+    processing_mode: bdba.model.ProcessingMode = bdba.model.ProcessingMode.RESCAN
+
+
+@dataclasses.dataclass
+class BDBAConfig(BacklogItemMixins):
+    '''
+    :param str delivery_service_url
+    :param list[BDBAMapping] mappings
+    :param int interval:
+        Time after which an artefact must be re-scanned at latest.
+    :param WarningVerbosities on_unsupported
+        Defines the handling if a backlog item should be processed which contains unsupported
+        properties, e.g. an unsupported access type.
+    '''
+    delivery_service_url: str
+    mappings: list[BDBAMapping]
+    interval: int = 60 * 60 * 24 # 24h
+    on_unsupported: WarningVerbosities = WarningVerbosities.WARNING
+
+    def mapping(self, name: str, /) -> BDBAMapping:
+        for mapping in self.mappings:
+            if name.startswith(mapping.prefix):
+                return mapping
+
+        raise ValueError(f'No matching mapping entry found for {name=}')
+
+    def is_supported(
+        self,
+        artefact_kind: dso.model.ArtefactKind | None=None,
+        access_type: ocm.AccessType | None=None,
+    ) -> bool:
+        supported_artefact_kinds = (
+            dso.model.ArtefactKind.RESOURCE,
+        )
+        supported_access_types = (
+            ocm.AccessType.OCI_REGISTRY,
+            ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.S3,
+        )
+
+        is_supported = True
+
+        if artefact_kind and artefact_kind not in supported_artefact_kinds:
+            is_supported = False
+
+        if access_type and access_type not in supported_access_types:
+            is_supported = False
+
+        if is_supported:
+            return True
+
+        error_msg = (
+            f'{artefact_kind=} and/or {access_type=} are/is not supported '
+            f'({supported_artefact_kinds=}; {supported_access_types=})'
+        )
+
+        if self.on_unsupported is WarningVerbosities.FAIL:
+            raise ValueError(error_msg)
+        elif self.on_unsupported is WarningVerbosities.WARNING:
+            logger.warning(error_msg)
+        elif self.on_unsupported is WarningVerbosities.IGNORE:
+            pass
+
+        return False
+
+
+@dataclasses.dataclass(frozen=True)
+class CachePruningWeights:
+    '''
+    The individual weights determine how much the respective values are being considered when
+    determining those cache entries which should be deleted next (in case the max cache size is
+    reached). The greater the weight, the less likely an entry will be considered for deletion.
+    Negative values may be also used to express a property which determines that an entry should
+    be deleted. 0 means the property does not affect the priority for the next deletion.
+    '''
+    creation_date_weight: float = 0
+    last_update_weight: float = 0
+    delete_after_weight: float = 0
+    keep_until_weight: float = 0
+    last_read_weight: float = 0
+    read_count_weight: float = 0
+    revision_weight: float = 0
+    costs_weight: float = 0
+    size_weight: float = 0
+
+    @staticmethod
+    def default() -> typing.Self:
+        return CachePruningWeights(
+            creation_date_weight=0,
+            last_update_weight=0,
+            delete_after_weight=-1.5, # deletion (i.e. stale) flag -> delete
+            keep_until_weight=-1, # keep until has passed -> delete
+            last_read_weight=-1, # long time no read -> delete
+            read_count_weight=10, # has many reads -> rather not delete
+            revision_weight=0,
+            costs_weight=10, # is expensive to re-calculate -> rather not delete
+            size_weight=0,
+        )
+
+
+class FunctionNames(enum.StrEnum):
+    COMPLIANCE_SUMMARY = 'compliance-summary'
+    COMPONENT_VERSIONS = 'component-versions'
+
+
+@dataclasses.dataclass
+class PrefillFunctionCaches:
+    components: list[Component] = dataclasses.field(default_factory=list)
+    functions: list[FunctionNames] = dataclasses.field(default_factory=lambda: [f for f in FunctionNames]) # noqa: E501
+
+
+@dataclasses.dataclass
+class CacheManagerConfig:
+    '''
+    :param str schedule
+    :param int max_cache_size_bytes
+    :param int min_pruning_bytes:
+        If `max_cache_size_bytes` is reached, existing cache entries will be removed according to
+        the `cache_pruning_weights` until `min_pruning_bytes` is available again.
+    :param CachePruningWeights cache_pruning_weights
+    :param PrefillFunctionCaches prefill_function_caches:
+        Configures components for which to pre-calculate and cache the desired functions. If no
+        specific functions are set, all available functions will be considered.
+    '''
+    schedule: str = '*/10 * * * *' # every 10 minutes
+    max_cache_size_bytes: int = 1000000000 # 1Gb
+    min_pruning_bytes: int = 100000000 # 100Mb
+    cache_pruning_weights: CachePruningWeights = dataclasses.field(default_factory=CachePruningWeights.default) # noqa: E501
+    prefill_function_caches: PrefillFunctionCaches = dataclasses.field(default_factory=PrefillFunctionCaches) # noqa: E501
+
+
+@dataclasses.dataclass
+class ClamAVMapping(Mapping):
+    '''
+    :param str aws_secret_name
+        Name of the AWS secret element to use to retrieve artefacts from S3.
+    '''
+    aws_secret_name: str | None
+
+
+@dataclasses.dataclass
+class ClamAVConfig(BacklogItemMixins):
+    '''
+    :param str delivery_service_url
+    :param list[ClamAVMapping] mappings
+    :param int interval:
+        Time after which an artefact must be re-scanned at latest.
+    :param WarningVerbosities on_unsupported
+        Defines the handling if a backlog item should be processed which contains unsupported
+        properties, e.g. an unsupported access type.
+    '''
+    delivery_service_url: str
+    mappings: list[ClamAVMapping]
+    interval: int = 60 * 60 * 24 # 24h
+    on_unsupported: WarningVerbosities = WarningVerbosities.WARNING
+
+    def mapping(self, name: str, /) -> ClamAVMapping:
+        for mapping in self.mappings:
+            if name.startswith(mapping.prefix):
+                return mapping
+
+        raise ValueError(f'No matching mapping entry found for {name=}')
+
+    def is_supported(
+        self,
+        artefact_kind: dso.model.ArtefactKind | None=None,
+        access_type: ocm.AccessType | None=None,
+    ) -> bool:
+        supported_artefact_kinds = (
+            dso.model.ArtefactKind.RESOURCE,
+        )
+        supported_access_types = (
+            ocm.AccessType.OCI_REGISTRY,
+            ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.S3,
+        )
+
+        is_supported = True
+
+        if artefact_kind and artefact_kind not in supported_artefact_kinds:
+            is_supported = False
+
+        if access_type and access_type not in supported_access_types:
+            is_supported = False
+
+        if is_supported:
+            return True
+
+        error_msg = (
+            f'{artefact_kind=} and/or {access_type=} are/is not supported '
+            f'({supported_artefact_kinds=}; {supported_access_types=})'
+        )
+
+        if self.on_unsupported is WarningVerbosities.FAIL:
+            raise ValueError(error_msg)
+        elif self.on_unsupported is WarningVerbosities.WARNING:
+            logger.warning(error_msg)
+        elif self.on_unsupported is WarningVerbosities.IGNORE:
+            pass
+
+        return False
+
+
+@dataclasses.dataclass
+class DeliveryDBBackup:
+    '''
+    :param str delivery_service_url
+    :param str component_name:
+        The desired name of the OCM component which will contain the backup resource.
+    :param str ocm_repo_url:
+        The OCM repository to which the component will be published.
+    :param int backup_retention_count:
+        The number of backup versions to keep. In case there are more backups, the oldest backups
+        will be removed.
+    :param str initial_version:
+        Upon a new backup, there will be an automatic minor version upgrade. This defines the
+        initial version if the backup component does not exist yet.
+    :param list[str] extra_pg_dump_args:
+        List of arguments that is passed to the `pg_dump` command as-is.
+    :param int successful_jobs_history_limit
+    :param int failed_jobs_history_limit
+    '''
+    delivery_service_url: str
+    component_name: str
+    ocm_repo_url: str
+    backup_retention_count: int | None
+    initial_version: str = '0.1.0'
+    schedule: str = '0 0 * * *' # every day at 12:00 AM
+    extra_pg_dump_args: list[str] = dataclasses.field(default_factory=list)
+    successful_jobs_history_limit: int = 1
+    failed_jobs_history_limit: int = 1
+
+
+@dataclasses.dataclass
+class IssueReplicatorMapping(Mapping):
+    '''
+    :param str github_repository
+        GitHub repository name where the issues should be created.
+    :param list[str] github_issue_labels_to_preserve:
+        Labels matching one of these regexes won't be removed upon an issue update.
+    :param int number_included_closed_issues:
+        Number of closed issues to consider when evaluating creating vs re-opening an issue.
+    :param MilestoneConfiguration milestones:
+        Configuration to overwrite how the configured sprints are turned into GitHub milestones.
+    '''
+    github_repository: str
+    github_issue_labels_to_preserve: list[str] = dataclasses.field(default_factory=list)
+    number_included_closed_issues: int = 100
+    milestones: gcmi.MilestoneConfiguration | dict = dataclasses.field(default_factory=gcmi.MilestoneConfiguration) # noqa: E501
+
+    def __post_init__(self):
+        if isinstance(self.milestones, dict):
+            if milestone_title_cfg := self.milestones.get('title'):
+                title_prefix = milestone_title_cfg.get('prefix')
+                title_suffix = milestone_title_cfg.get('suffix')
+                title_sprint_cfg = milestone_title_cfg.get('sprint')
+            else:
+                title_prefix = gcmi.MilestoneConfiguration.title_prefix
+                title_suffix = gcmi.MilestoneConfiguration.title_suffix
+                title_sprint_cfg = None
+
+            if title_sprint_cfg:
+                if (sprint_value_type := title_sprint_cfg.get('value_type')) == 'name':
+                    title_callback = lambda sprint: sprint.name
+
+                elif sprint_value_type == 'date':
+                    name = title_sprint_cfg.get('date_name', 'end_date')
+                    str_format = title_sprint_cfg.get('date_string_format', '%Y-%m-%d')
+
+                    title_callback = lambda sprint: sprint.find_sprint_date(name).value.strftime(str_format) # noqa: E501
+
+                else:
+                    raise ValueError(f'invalid milestone sprint value type {sprint_value_type}')
+
+            else:
+                title_callback = gcmi.MilestoneConfiguration.title_callback
+
+            if milestone_due_date_cfg := self.milestones.get('due_date'):
+                name = milestone_due_date_cfg['date_name']
+                due_date_callback = lambda sprint: sprint.find_sprint_date(name).value
+            else:
+                due_date_callback = gcmi.MilestoneConfiguration.due_date_callback
+
+            self.milestones = gcmi.MilestoneConfiguration(
+                title_callback=title_callback,
+                title_prefix=title_prefix,
+                title_suffix=title_suffix,
+                due_date_callback=due_date_callback,
+            )
+
+    @functools.cached_property
+    def repository(self) -> github3.repos.Repository:
+        github_api_lookup = lookups.github_api_lookup()
+        github_repo_lookup = lookups.github_repo_lookup(github_api_lookup)
+
+        return github_repo_lookup(self.github_repository)
+
+    @functools.cached_property
+    def github_api(self) -> github3.github.GitHub:
+        github_api_lookup = lookups.github_api_lookup()
+
+        return github_api_lookup(self.repository.html_url)
+
+
+@dataclasses.dataclass
+class IssueReplicatorConfig(BacklogItemMixins):
+    '''
+    :param str delivery_service_url
+    :param str delivery_dashboard_url
+    :param list[IssueReplicatorMapping] mappings
+    :param int interval:
+        Time after which an issue must be updated at latest.
+    '''
+    delivery_service_url: str
+    delivery_dashboard_url: str
+    mappings: list[IssueReplicatorMapping]
+    interval: int = 60 * 60 # 1h
+
+    def mapping(self, name: str, /) -> IssueReplicatorMapping:
+        for mapping in self.mappings:
+            if name.startswith(mapping.prefix):
+                return mapping
+
+        raise ValueError(f'No matching mapping entry found for {name=}')
+
+    def is_supported(
+        self,
+        artefact_kind: dso.model.ArtefactKind | None=None,
+        access_type: ocm.AccessType | None=None,
+    ) -> bool:
+        return True # issue replication works independent of any artefact or access type
+
+
+@dataclasses.dataclass
+class SASTConfig:
+    '''
+    :param str delivery_service_url
+    :param list[Component] components:
+        Components which should be analysed.
+    '''
+    delivery_service_url: str
+    components: list[Component]
+
+
+@dataclasses.dataclass
+class ScanConfiguration:
+    artefact_enumerator: ArtefactEnumeratorConfig | None
+    bdba: BDBAConfig | None
+    clamav: ClamAVConfig | None
+    cache_manager: CacheManagerConfig | None
+    delivery_db_backup: DeliveryDBBackup | None
+    issue_replicator: IssueReplicatorConfig | None
+    sast: SASTConfig | None
+    backlog_controller: BacklogControllerConfig = dataclasses.field(default_factory=BacklogControllerConfig) # noqa: E501
+
+    @staticmethod
+    def from_dict(scan_configuration_raw: dict) -> typing.Self:
+        # mix-in default values in extension-specific ones
+        defaults = scan_configuration_raw.get('defaults', {})
+        for extension, extension_cfg in scan_configuration_raw.items():
+            scan_configuration_raw[extension] = defaults | extension_cfg
+
+        return dacite.from_dict(
+            data_class=ScanConfiguration,
+            data=scan_configuration_raw,
+            config=dacite.Config(
+                cast=[enum.Enum],
+            ),
+        )
+
+    @staticmethod
+    def from_file(path: str) -> typing.Self:
+        with open(path) as file:
+            scan_configuration_raw = yaml.safe_load(file)
+
+        return ScanConfiguration.from_dict(
+            scan_configuration_raw=scan_configuration_raw,
+        )

--- a/setup.utils.py
+++ b/setup.utils.py
@@ -38,8 +38,15 @@ def packages():
     return [
         'deliverydb_cache',
         'k8s',
+        'odg',
         'secret_mgmt',
     ]
+
+
+def package_data():
+    return {
+        'odg': ['*.yaml'],
+    }
 
 
 setuptools.setup(
@@ -47,5 +54,6 @@ setuptools.setup(
     version=setup.finalize_version(),
     py_modules=modules(),
     packages=packages(),
+    package_data=package_data(),
     install_requires=list(requirements()),
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
As a first step, these model classes are kept totally redundant to the current ones defined in `config.py` to allow a step-by-step transition towards the overhauled cfg-mgmt. This will allow existing extensions and in the end the delivery-service + -dashboard themselves to switch to the overhauled cfg-mgmt one by one as long as the provided configuration is kept semantically equal.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
Add new `odg` package containing overhauled and new model classes
```
