### PR TITLE
Introduce `enabled` flag to extension cfgs

### DIFF
--- a/odg/scan_cfg.py
+++ b/odg/scan_cfg.py
@@ -41,8 +41,13 @@ class WarningVerbosities(enum.StrEnum):
     WARNING = 'warning'
 
 
+@dataclasses.dataclass(kw_only=True)
+class ScanConfigMixins:
+    enabled: bool = True
+
+
 @dataclasses.dataclass
-class BacklogItemMixins:
+class BacklogItemMixins(ScanConfigMixins):
     '''
     Defines properties and functions which are shared among those extensions which determine their
     workload using the BacklogItem custom resource.
@@ -96,7 +101,7 @@ class TimeRange:
 
 
 @dataclasses.dataclass
-class ArtefactEnumeratorConfig:
+class ArtefactEnumeratorConfig(ScanConfigMixins):
     '''
     :param str delivery_service_url
     :param list[Component] components:
@@ -120,7 +125,7 @@ class ArtefactEnumeratorConfig:
 
 
 @dataclasses.dataclass
-class BacklogControllerConfig:
+class BacklogControllerConfig(ScanConfigMixins):
     '''
     :param int max_replicas:
         Maximum number of replicas per extension to which the backlog controller will scale. Note,
@@ -263,7 +268,7 @@ class PrefillFunctionCaches:
 
 
 @dataclasses.dataclass
-class CacheManagerConfig:
+class CacheManagerConfig(ScanConfigMixins):
     '''
     :param int max_cache_size_bytes
     :param int min_pruning_bytes:
@@ -373,7 +378,7 @@ class ClamAVConfig(BacklogItemMixins):
 
 
 @dataclasses.dataclass
-class DeliveryDBBackup:
+class DeliveryDBBackup(ScanConfigMixins):
     '''
     :param str delivery_service_url
     :param str component_name:

--- a/test/test_extension_cfg.py
+++ b/test/test_extension_cfg.py
@@ -1,0 +1,29 @@
+import pytest
+
+import odg.scan_cfg
+
+
+@pytest.fixture
+def extension_cfg() -> odg.scan_cfg.ScanConfiguration:
+    raw = {
+        'defaults': {
+            'delivery_service_url': 'foo',
+        },
+        'sast': {
+            'enabled': True,
+        },
+        'bdba': {
+            'enabled': False,
+            'mappings': [],
+        },
+        'clamav': {
+            'mappings': []
+        },
+    }
+    return odg.scan_cfg.ScanConfiguration.from_dict(raw)
+
+
+def test_enabled_defaults(extension_cfg: odg.scan_cfg.ScanConfiguration):
+    assert extension_cfg.sast.enabled is True
+    assert extension_cfg.bdba.enabled is False
+    assert extension_cfg.clamav.enabled is True


### PR DESCRIPTION
Allows explicit control whether an extension should be enabled. Previously, this was handled implicitly by absence of configuration.

This is useful for two reasons:
- allows operator to toggle extension state with minimal effort (plus one can keep "old" configuration)
- is more intuitive in case an extension does not provide configuration (e.g. because defaults are sufficient, like in SAST case)

This change is backwards compatible and defaults to `True`.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
ODG extension state can now be explicitly toggled via `enabled` flag (backwards compatible)
```
