### PR TITLE
Fix: Close issues which "fell out" of the configured time range

### DIFF
--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -111,7 +111,9 @@ class ArtefactEnumeratorConfig(ExtensionCfgMixins):
         Earliest start and latest end date for which compliance snapshots should be created. If not
         set, all available sprints will be considered.
     :param int compliance_snapshot_grace_period:
-        Time after which inactive compliance snapshots are deleted from the delivery-db.
+        Time after which inactive compliance snapshots are deleted from the delivery-db. During this
+        period, the inactive snapshots are used to possibly close outdated GitHub issues (i.e. the
+        ones which have a due date which is by now out-of-scope of the configured time range).
     :param str schedule
     :param int successful_jobs_history_limit
     :param int failed_jobs_history_limit


### PR DESCRIPTION
**What this PR does / why we need it**:
The artefact enumerator is configured with a time range for which it creates respective compliance snapshots. As these compliance snapshots (or more precisely: their correlation id), is used as a reference to the GitHub issues, only issues which have a correlation id for which a compliance snapshot exists are being considered for the automatic issue lifecycle. Now, if a compliance snapshot becomes inactive and no new snapshot is created with the same correlation id (because by now the due date is not part of the configured interval anymore), the respective GitHub issue is not considered anymore by the automatic issue lifecycle.

To mitigate this, this fix will consider all sprints (for active and inactive snapshots), but will only assign findings to the active ones, whereby GitHub issues for the inactive ones will be closed because they have no assigned findings anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fix missing GitHub issue update for issues which are not part of the configured time range anymore
```
