### PR TITLE
Allow custom GitHub issue grouping in finding-cfg 

### DIFF
--- a/artefact_enumerator.py
+++ b/artefact_enumerator.py
@@ -3,7 +3,6 @@ import atexit
 import collections
 import collections.abc
 import datetime
-import hashlib
 import logging
 import os
 
@@ -49,30 +48,6 @@ def sprint_dates(
     return sprint_dates
 
 
-def correlation_id(
-    artefact: dso.model.ComponentArtefactId,
-    latest_processing_date: datetime.date,
-    version: str='v1',
-) -> str:
-    '''
-    the correlation id neither contains the `component_version` nor the
-    `artefact_version` to group compliance snapshots of the same artefact
-    across different versions (e.g. necessary for GitHub tracking issues).
-    Also, a version prefix is added to be able to differentiate correlation
-    ids in case their calculation changed
-    '''
-    digest_str = (
-        artefact.component_name + artefact.artefact_kind +
-        artefact.artefact.artefact_name + artefact.artefact.artefact_type +
-        latest_processing_date.isoformat()
-    )
-    digest = hashlib.shake_128(digest_str.encode('utf-8')).hexdigest(
-        length=23,
-    )
-
-    return f'{version}/{digest}'
-
-
 def create_compliance_snapshot(
     artefact: dso.model.ComponentArtefactId,
     latest_processing_date: datetime.date,
@@ -88,10 +63,6 @@ def create_compliance_snapshot(
 
     data = dso.model.ComplianceSnapshot(
         latest_processing_date=latest_processing_date,
-        correlation_id=correlation_id(
-            artefact=artefact,
-            latest_processing_date=latest_processing_date,
-        ),
         state=[dso.model.ComplianceSnapshotState(
             timestamp=now,
             status=dso.model.ComplianceSnapshotStatuses.ACTIVE,

--- a/issue_replicator/__main__.py
+++ b/issue_replicator/__main__.py
@@ -208,7 +208,7 @@ def replicate_issue_for_finding_type(
 
     logger.info(f'updating issues for {finding_type=} and {finding_source=}')
 
-    artefact_group = finding_cfg.issues.grouping.strip_artefact(
+    artefact_group = finding_cfg.issues.strip_artefact(
         artefact=artefact,
         keep_group_attributes=True,
     )
@@ -282,7 +282,7 @@ def replicate_issue_for_finding_type(
     # both sides have to be normalised in that the component version is not considered. Also, the
     # attributes by which artefacts are grouped are dropped as they are equal anyways.
     all_artefacts = {
-        finding_cfg.issues.grouping.strip_artefact(
+        finding_cfg.issues.strip_artefact(
             artefact=dataclasses.replace(
                 artefact,
                 component_version=None,
@@ -291,7 +291,7 @@ def replicate_issue_for_finding_type(
         ) for artefact in artefacts
     }
     scanned_artefacts = {
-        finding_cfg.issues.grouping.strip_artefact(
+        finding_cfg.issues.strip_artefact(
             artefact=dataclasses.replace(
                 finding.finding.artefact,
                 component_version=None,

--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -74,7 +74,7 @@ class FindingGroup:
             artefact=self.artefact,
         )
 
-        artefact_non_group_properties = finding_cfg.issues.grouping.strip_artefact(
+        artefact_non_group_properties = finding_cfg.issues.strip_artefact(
             artefact=self.artefact,
             keep_group_attributes=False,
         )
@@ -744,7 +744,7 @@ def _template_vars(
     ''')
 
     # first of all, display the artefact properties which are used for grouping in the summary table
-    artefact_group_properties = finding_cfg.issues.grouping.strip_artefact(
+    artefact_group_properties = finding_cfg.issues.strip_artefact(
         artefact=artefact,
         keep_group_attributes=True,
     )
@@ -800,7 +800,7 @@ def _template_vars(
 
     # secondly, display the combinations of artefact properties which are not part of the group
     artefacts_non_group_properties = [
-        finding_cfg.issues.grouping.strip_artefact(
+        finding_cfg.issues.strip_artefact(
             artefact=finding_group.artefact,
             keep_group_attributes=False,
         ) for finding_group in finding_groups

--- a/k8s/backlog.py
+++ b/k8s/backlog.py
@@ -110,23 +110,8 @@ def iter_existing_backlog_items_for_artefact(
             ),
         )
 
-        if service in (
-            odg.extensions_cfg.Services.BDBA,
-            odg.extensions_cfg.Services.CLAMAV,
-            odg.extensions_cfg.Services.SAST,
-        ):
-            if crd_artefact == artefact:
-                yield backlog_crd
-        elif service is odg.extensions_cfg.Services.ISSUE_REPLICATOR:
-            if (
-                crd_artefact.artefact_kind is artefact.artefact_kind
-                and crd_artefact.component_name == artefact.component_name
-                and crd_artefact.artefact.artefact_name == artefact.artefact.artefact_name
-                and crd_artefact.artefact.artefact_type == artefact.artefact.artefact_type
-            ):
-                yield backlog_crd
-        else:
-            raise NotImplementedError(f'{service=} is not valid for a backlog item')
+        if crd_artefact == artefact:
+            yield backlog_crd
 
 
 def create_backlog_item(


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Example configuration which matches the status-quo:
```yaml
type: finding/vulnerability
issues:
  enable_issues: True
  attrs_to_group_by:
    - component_name
    - artefact_kind
    - artefact.artefact_name
    - artefact.artefact_type
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added optional grouping configuration to configure grouping rules for GitHub issue replication
```
