### PR TITLE
Add target namespace overwrite via values (not built-in helm objects only)

### DIFF
--- a/charts/bootstrapping/templates/extensions-cfg.yaml
+++ b/charts/bootstrapping/templates/extensions-cfg.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: extensions-cfg
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 data:
   extensions_cfg: |
     {{- toYaml $extensions_cfg | nindent 4 }}

--- a/charts/bootstrapping/templates/features-cfg.yaml
+++ b/charts/bootstrapping/templates/features-cfg.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: features-cfg
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 type: Opaque
 stringData:
   features_cfg: |

--- a/charts/bootstrapping/templates/findings.yaml
+++ b/charts/bootstrapping/templates/findings.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: findings-cfg
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 data:
   findings_cfg: |
     {{- toYaml $findings | nindent 4 }}

--- a/charts/bootstrapping/templates/ocm-repo-mappings.yaml
+++ b/charts/bootstrapping/templates/ocm-repo-mappings.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ocm-repo-mappings
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 data:
   ocm_repo_mappings: |
     {{- toYaml $ocm_repo_mappings | nindent 4 }}

--- a/charts/bootstrapping/templates/profiles.yaml
+++ b/charts/bootstrapping/templates/profiles.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: profiles
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 data:
   profiles: |
     {{- toYaml $profiles | nindent 4 }}

--- a/charts/bootstrapping/templates/secrets.yaml
+++ b/charts/bootstrapping/templates/secrets.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: secret-factory-aws
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 type: Opaque
 stringData: {{ include "secret" $secrets.aws }}
 ---
@@ -13,6 +14,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: secret-factory-bdba
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 type: Opaque
 stringData: {{ include "secret" $secrets.bdba }}
 ---
@@ -22,6 +24,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: secret-factory-delivery-db
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 type: Opaque
 stringData: {{ include "secret" (index $secrets "delivery-db") }}
 ---
@@ -31,6 +34,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: secret-factory-github
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 type: Opaque
 stringData: {{ include "secret" $secrets.github }}
 ---
@@ -40,6 +44,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: secret-factory-kubernetes
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 type: Opaque
 stringData: {{ include "secret" $secrets.kubernetes }}
 ---
@@ -49,6 +54,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: secret-factory-oauth-cfg
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 type: Opaque
 stringData: {{ include "secret" (index $secrets "oauth-cfg") }}
 ---
@@ -58,6 +64,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: secret-factory-oci-registry
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 type: Opaque
 stringData: {{ include "secret" (index $secrets "oci-registry") }}
 ---
@@ -67,6 +74,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: secret-factory-signing-cfg
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 type: Opaque
 stringData: {{ include "secret" (index $secrets "signing-cfg") }}
 ---

--- a/charts/delivery-service/templates/horizontal-pod-autoscaler.yaml
+++ b/charts/delivery-service/templates/horizontal-pod-autoscaler.yaml
@@ -2,6 +2,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: delivery-service
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
   {{- if default dict (.Values.autoscaler).annotations }}
   annotations:
   {{- range $annotation, $value := .Values.autoscaler.annotations }}

--- a/charts/delivery-service/templates/rbac.yaml
+++ b/charts/delivery-service/templates/rbac.yaml
@@ -3,6 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocm-gear
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 rules:
   - apiGroups:
       - ""
@@ -29,10 +30,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocm-gear
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 roleRef:
   kind: Role
   name: ocm-gear

--- a/charts/delivery-service/templates/service-deployment.yaml
+++ b/charts/delivery-service/templates/service-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: delivery-service
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   selector:
     matchLabels:
@@ -63,7 +64,7 @@ spec:
           - name: PROFILES_PATH
             value: /profiles/profiles
           - name: K8S_TARGET_NAMESPACE
-            value: {{ .Release.Namespace }}
+            value: {{ .Values.target_namespace | default .Release.Namespace }}
           {{- if default dict .Values.envVars }}
           {{- range $key, $value := .Values.envVars }}
           - name: {{ $key }}

--- a/charts/delivery-service/templates/service-ingress.yaml
+++ b/charts/delivery-service/templates/service-ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: delivery-service
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
   annotations:
     cert.gardener.cloud/purpose: managed
     dns.gardener.cloud/class: garden

--- a/charts/delivery-service/templates/service-service.yaml
+++ b/charts/delivery-service/templates/service-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: delivery-service
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
   labels:
     app: delivery-service
 spec:

--- a/charts/extensions/charts/artefact-enumerator/templates/artefact-enumerator.yaml
+++ b/charts/extensions/charts/artefact-enumerator/templates/artefact-enumerator.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: artefact-enumerator
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   schedule: {{ default "*/5 * * * *" .Values.schedule | quote }} # schedule may contain asterisks, quote to avoid yaml parser errors
   concurrencyPolicy: Forbid
@@ -32,7 +33,7 @@ spec:
             - name: OCM_REPO_MAPPINGS_PATH
               value: /ocm_repo_mappings/ocm_repo_mappings
             - name: K8S_TARGET_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Values.target_namespace | default .Release.Namespace }}
             volumeMounts:
             - name: github
               mountPath: /secrets/github

--- a/charts/extensions/charts/backlog-controller/templates/backlog-controller.yaml
+++ b/charts/extensions/charts/backlog-controller/templates/backlog-controller.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: backlog-controller
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -26,7 +27,7 @@ spec:
             - name: EXTENSIONS_CFG_PATH
               value: /extensions_cfg/extensions_cfg
             - name: K8S_TARGET_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Values.target_namespace | default .Release.Namespace }}
           volumeMounts:
             - name: kubernetes
               mountPath: /secrets/kubernetes

--- a/charts/extensions/charts/bdba/templates/bdba.yaml
+++ b/charts/extensions/charts/bdba/templates/bdba.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: bdba
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
@@ -40,7 +41,7 @@ spec:
             - name: OCM_REPO_MAPPINGS_PATH
               value: /ocm_repo_mappings/ocm_repo_mappings
             - name: K8S_TARGET_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Values.target_namespace | default .Release.Namespace }}
           volumeMounts:
             - name: aws
               mountPath: /secrets/aws

--- a/charts/extensions/charts/cache-manager/templates/cache-manager.yaml
+++ b/charts/extensions/charts/cache-manager/templates/cache-manager.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cache-manager
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   schedule: {{ default "*/10 * * * *" .Values.schedule | quote }} # schedule contains asterisks, quote to avoid yaml parser errors
   concurrencyPolicy: Forbid
@@ -38,7 +39,7 @@ spec:
             - name: OCM_REPO_MAPPINGS_PATH
               value: /ocm_repo_mappings/ocm_repo_mappings
             - name: K8S_TARGET_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Values.target_namespace | default .Release.Namespace }}
             volumeMounts:
             - name: delivery-db
               mountPath: /secrets/delivery-db

--- a/charts/extensions/charts/clamav/templates/clamav.yaml
+++ b/charts/extensions/charts/clamav/templates/clamav.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: clamav
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
@@ -36,7 +37,7 @@ spec:
             - name: OCM_REPO_MAPPINGS_PATH
               value: /ocm_repo_mappings/ocm_repo_mappings
             - name: K8S_TARGET_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Values.target_namespace | default .Release.Namespace }}
           volumeMounts:
             - name: aws
               mountPath: /secrets/aws

--- a/charts/extensions/charts/clamav/templates/freshclam-config.yaml
+++ b/charts/extensions/charts/clamav/templates/freshclam-config.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: clamav-freshclam-config
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 data:
   freshclam: |-
-    DatabaseMirror freshclam.{{ .Release.Namespace }}.svc.cluster.local:8080
-    PrivateMirror freshclam.{{ .Release.Namespace }}.svc.cluster.local:8080
+    DatabaseMirror freshclam.{{ .Values.target_namespace | default .Release.Namespace }}.svc.cluster.local:8080
+    PrivateMirror freshclam.{{ .Values.target_namespace | default .Release.Namespace }}.svc.cluster.local:8080

--- a/charts/extensions/charts/clamav/templates/freshclam-service.yaml
+++ b/charts/extensions/charts/clamav/templates/freshclam-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: freshclam
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
   labels:
     app: freshclam
 spec:

--- a/charts/extensions/charts/clamav/templates/freshclam.yaml
+++ b/charts/extensions/charts/clamav/templates/freshclam.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: freshclam
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/charts/extensions/charts/crypto/templates/crypto.yaml
+++ b/charts/extensions/charts/crypto/templates/crypto.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: crypto
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
@@ -40,7 +41,7 @@ spec:
             - name: OCM_REPO_MAPPINGS_PATH
               value: /ocm_repo_mappings/ocm_repo_mappings
             - name: K8S_TARGET_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Values.target_namespace | default .Release.Namespace }}
           volumeMounts:
             - name: aws
               mountPath: /secrets/aws

--- a/charts/extensions/charts/delivery-db-backup/templates/delivery-db-backup.yaml
+++ b/charts/extensions/charts/delivery-db-backup/templates/delivery-db-backup.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: delivery-db-backup
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   schedule: {{ default "0 0 * * *" .Values.schedule | quote }} # schedule contains asterisks, quote to avoid yaml parser errors
   concurrencyPolicy: Forbid
@@ -28,7 +29,7 @@ spec:
             - name: EXTENSIONS_CFG_PATH
               value: /extensions_cfg/extensions_cfg
             - name: K8S_TARGET_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Values.target_namespace | default .Release.Namespace }}
             volumeMounts:
             - name: delivery-db
               mountPath: /secrets/delivery-db

--- a/charts/extensions/charts/issue-replicator/templates/issue-replicator.yaml
+++ b/charts/extensions/charts/issue-replicator/templates/issue-replicator.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: issuereplicator
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
@@ -33,7 +34,7 @@ spec:
             - name: OCM_REPO_MAPPINGS_PATH
               value: /ocm_repo_mappings/ocm_repo_mappings
             - name: K8S_TARGET_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Values.target_namespace | default .Release.Namespace }}
           volumeMounts:
             - name: github
               mountPath: /secrets/github

--- a/charts/extensions/charts/sast/templates/sast.yaml
+++ b/charts/extensions/charts/sast/templates/sast.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: sast
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
@@ -40,7 +41,7 @@ spec:
             - name: OCM_REPO_MAPPINGS_PATH
               value: /ocm_repo_mappings/ocm_repo_mappings
             - name: K8S_TARGET_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Values.target_namespace | default .Release.Namespace }}
           volumeMounts:
             - name: github
               mountPath: /secrets/github


### PR DESCRIPTION
Useful for scenarios where helm release namespace cannot be controlled, e.g. when deploying using gardener-resource-manager.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add target namespace overwrite via values (not built-in helm objects only)
```
