### PR TITLE
Raise `503 service unavailable` error upon DB connection timeout

### DIFF
--- a/middleware/db_session.py
+++ b/middleware/db_session.py
@@ -1,6 +1,7 @@
 import aiohttp.typedefs
 import aiohttp.web
 import sqlalchemy
+import sqlalchemy.exc
 
 import consts
 import deliverydb
@@ -37,6 +38,9 @@ async def db_session_middleware(
 
         try:
             response = await handler(request)
+        except sqlalchemy.exc.TimeoutError:
+            # 503 error can be reacted upon by a load balancer to forward req to next pod
+            raise aiohttp.web.HTTPServiceUnavailable
         except Exception:
             raise
         finally:

--- a/middleware/db_session.py
+++ b/middleware/db_session.py
@@ -28,7 +28,10 @@ async def db_session_middleware(
         request: aiohttp.web.Request,
         handler: aiohttp.typedefs.Handler,
     ) -> aiohttp.web.StreamResponse:
-        request[consts.REQUEST_DB_SESSION] = await deliverydb.sqlalchemy_session(db_url)
+        request[consts.REQUEST_DB_SESSION] = await deliverydb.sqlalchemy_session(
+            db_url=db_url,
+            pool_timeout=5,
+        )
         request[consts.REQUEST_DB_SESSION_LOW_PRIO] = await deliverydb.sqlalchemy_session(
             db_url=db_url,
             pool_size=2,


### PR DESCRIPTION
**What this PR does / why we need it**:
A DB connection timeout error is raised in case the session pool is full, i.e. the pool size of "5" and the possible overflow of "10" is exceeded. In that case, raise a http 503 error so that the load balancer (ingress nginx controller) is able to forward the request to the next available pod which might have a session pool capacity left.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
A http `503 service unavailable` error is now raised in case a DB connection timeout occurs
```
