### PR TITLE
Wrap replica-sets in deployments

### DIFF
--- a/backlog_controller.py
+++ b/backlog_controller.py
@@ -101,7 +101,7 @@ def on_backlog_change(
     items_per_replica = backlog_controller_cfg.backlog_items_per_replica
     desired_replicas = min(math.ceil(len(backlog_crds) / items_per_replica), max_replicas)
 
-    k8s.util.scale_replica_set(
+    k8s.util.scale_replicas(
         service=service,
         namespace=namespace,
         kubernetes_api=kubernetes_api,

--- a/charts/extensions/charts/bdba/templates/bdba.yaml
+++ b/charts/extensions/charts/bdba/templates/bdba.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: ReplicaSet
+kind: Deployment
 metadata:
   name: bdba
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}

--- a/charts/extensions/charts/clamav/templates/clamav.yaml
+++ b/charts/extensions/charts/clamav/templates/clamav.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: ReplicaSet
+kind: Deployment
 metadata:
   name: clamav
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}

--- a/charts/extensions/charts/crypto/templates/crypto.yaml
+++ b/charts/extensions/charts/crypto/templates/crypto.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: ReplicaSet
+kind: Deployment
 metadata:
   name: crypto
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}

--- a/charts/extensions/charts/issue-replicator/templates/issue-replicator.yaml
+++ b/charts/extensions/charts/issue-replicator/templates/issue-replicator.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: ReplicaSet
+kind: Deployment
 metadata:
   name: issuereplicator
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}

--- a/charts/extensions/charts/sast/templates/sast.yaml
+++ b/charts/extensions/charts/sast/templates/sast.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: ReplicaSet
+kind: Deployment
 metadata:
   name: sast
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}


### PR DESCRIPTION
**What this PR does / why we need it**:
There are several reasons:
- consistency with our other helmcharts
- established best practise in k8s community
- technical benefits, e.g. controlled rollout of new image versions
- gardener-resource-manager does not support "preserve-replicas" for
  replica-sets

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
ODG extension replica-sets are wrapped via `Deployment` 
```
