### PR TITLE
Assume delivery-service ingress is of class `nginx`

### DIFF
--- a/charts/delivery-service/templates/service-ingress.yaml
+++ b/charts/delivery-service/templates/service-ingress.yaml
@@ -7,11 +7,16 @@ metadata:
     cert.gardener.cloud/purpose: managed
     dns.gardener.cloud/class: garden
     dns.gardener.cloud/dnsnames: "*"
+    nginx.ingress.kubernetes.io/proxy-body-size: 8m
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
+    nginx.ingress.kubernetes.io/proxy-next-upstream: error timeout http_503
+    nginx.ingress.kubernetes.io/proxy-next-upstream-timeout: "0"
+    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "0"
     {{- range $annotation, $value := default dict .Values.ingress.annotations }}
     {{ $annotation }}: {{ $value }}
     {{- end }}
 spec:
-  ingressClassName: {{ default "nginx" .Values.ingress.class }}
+  ingressClassName: nginx
   rules:
   {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}


### PR DESCRIPTION
When using nginx, these annotations are mandatory in ODG context. While the standlone installer offers flexibility and does not require to use nginx, we must avoid unnecessary flexibility for a managed offering.

Also, we did never test how the Ingress(es), DNS+Cert controller and other parts behave when using something else.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
Delivery-Service ingress now supports nginx only
```
