### PR TITLE
Only support postgres for managed ODG installations

### DIFF
--- a/local-setup/kind/cluster/values-bootstrapping.yaml
+++ b/local-setup/kind/cluster/values-bootstrapping.yaml
@@ -201,9 +201,6 @@ secrets:
   #       - ...
   delivery-db:
     local:
-      db_type: postgresql+psycopg
-      hostname: delivery-db.delivery.svc.cluster.local
-      port: 5432
       username: postgres
       password: password-123
   github:

--- a/secret_mgmt/__init__.py
+++ b/secret_mgmt/__init__.py
@@ -102,11 +102,8 @@ class SecretFactory:
 
             for delivery_db_cfg in delivery_db_cfgs:
                 secrets_dict['delivery-db'][delivery_db_cfg._name] = secret_mgmt.delivery_db.DeliveryDB( # noqa: E501
-                    hostname=delivery_db_cfg.hostname(),
-                    port=delivery_db_cfg.port(),
                     username=delivery_db_cfg.credentials().username(),
                     password=delivery_db_cfg.credentials().password(),
-                    db_type=delivery_db_cfg.db_type(),
                 )
 
         if github_cfgs := list(cfg_factory._cfg_elements(cfg_type_name='github')):

--- a/secret_mgmt/delivery_db.py
+++ b/secret_mgmt/delivery_db.py
@@ -3,12 +3,15 @@ import dataclasses
 
 @dataclasses.dataclass
 class DeliveryDB:
-    hostname: str
-    port: int
     username: str
     password: str
-    db_type: str = 'postgresql+psycopg'
 
-    @property
-    def url(self) -> str:
-        return f'{self.db_type}://{self.username}:{self.password}@{self.hostname}:{self.port}'
+    def connection_url(
+        self,
+        namespace: str,
+        service_name: str='delivery-db',
+        port: int=5432,
+        schema: str='postgresql+psycopg',
+    ) -> str:
+        hostname = f'{service_name}.{namespace}.svc.cluster.local'
+        return f'{schema}://{self.username}:{self.password}@{hostname}:{port}'


### PR DESCRIPTION
Different database technologies are still supported (e.g. sqlite for local dev), however only if db-url is passed directly via args.

When using central configuration approach (e.g. via mODG), assume database is of type postgres.
Also, remove redundant definition of cluster internal access aspects, such as runtime namespace.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
Only support postgres as delivery-db database technology for mODG instances
```
```improvement operator
Drop redundant cluster-specific namespace definition
```