### PR TITLE
Store `due_date` for findings + rescorings and allow manual processing-time inputs

### DIFF
--- a/artefact_enumerator.py
+++ b/artefact_enumerator.py
@@ -50,7 +50,7 @@ def sprint_dates(
 
 def create_compliance_snapshot(
     artefact: dso.model.ComponentArtefactId,
-    latest_processing_date: datetime.date,
+    due_date: datetime.date,
     now: datetime.datetime=datetime.datetime.now(),
     today: datetime.date=datetime.date.today(),
 ) -> dso.model.ArtefactMetadata:
@@ -62,7 +62,7 @@ def create_compliance_snapshot(
     )
 
     data = dso.model.ComplianceSnapshot(
-        latest_processing_date=latest_processing_date,
+        due_date=due_date,
         state=[dso.model.ComplianceSnapshotState(
             timestamp=now,
             status=dso.model.ComplianceSnapshotStatuses.ACTIVE,
@@ -128,14 +128,14 @@ def _create_and_update_compliance_snapshots_of_artefact(
     for sprint_date in sprints:
         if any(
             compliance_snapshot for compliance_snapshot in compliance_snapshots
-            if compliance_snapshot.data.latest_processing_date == sprint_date
+            if compliance_snapshot.data.due_date == sprint_date
         ):
             # compliance snapshot already exists for this artefact for this sprint
             continue
 
         compliance_snapshots.append(create_compliance_snapshot(
             artefact=artefact,
-            latest_processing_date=sprint_date,
+            due_date=sprint_date,
             now=now,
             today=today,
         ))

--- a/bdba_extension/util.py
+++ b/bdba_extension/util.py
@@ -158,6 +158,7 @@ def iter_artefact_metadata(
                     meta=meta,
                     data=license_finding,
                     discovery_date=discovery_date,
+                    allowed_processing_time=categorisation.allowed_processing_time_raw,
                 )
 
                 findings.append(artefact_metadata)
@@ -229,6 +230,7 @@ def iter_artefact_metadata(
                     meta=meta,
                     data=vulnerability_finding,
                     discovery_date=discovery_date,
+                    allowed_processing_time=categorisation.allowed_processing_time_raw,
                 )
 
                 findings.append(artefact_metadata)

--- a/crypto_extension/__main__.py
+++ b/crypto_extension/__main__.py
@@ -58,6 +58,7 @@ def as_artefact_metadata(
     artefact: dso.model.ComponentArtefactId,
     crypto_assets: collections.abc.Iterable[dso.model.CryptoAsset],
     findings: collections.abc.Iterable[dso.model.CryptoFinding],
+    crypto_finding_cfg: odg.findings.Finding,
 ) -> collections.abc.Generator[dso.model.ArtefactMetadata, None, None]:
     today = datetime.date.today()
     now = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -97,11 +98,14 @@ def as_artefact_metadata(
     )
 
     for finding in findings:
+        categorisation = crypto_finding_cfg.categorisation_by_id(finding.severity)
+
         yield dso.model.ArtefactMetadata(
             artefact=artefact,
             meta=meta,
             data=finding,
             discovery_date=today,
+            allowed_processing_time=categorisation.allowed_processing_time_raw,
         )
 
 
@@ -176,6 +180,7 @@ def scan(
         artefact=artefact,
         crypto_assets=crypto_assets,
         findings=findings,
+        crypto_finding_cfg=crypto_finding_cfg,
     ))
 
     existing_artefact_metadata = (

--- a/deliverydb/model.py
+++ b/deliverydb/model.py
@@ -49,6 +49,7 @@ class ArtefactMetaData(Base):
     referenced_type = sa.Column(sa.String(length=64)) # type of finding a rescoring applies to
 
     discovery_date = sa.Column(sa.Date)
+    allowed_processing_time = sa.Column(sa.String(length=16))
 
 
 sa.Index(

--- a/deliverydb/util.py
+++ b/deliverydb/util.py
@@ -58,6 +58,7 @@ def to_db_artefact_metadata(
         referenced_type=referenced_type,
         creation_date=meta.creation_date,
         discovery_date=artefact_metadata.discovery_date,
+        allowed_processing_time=artefact_metadata.allowed_processing_time,
     )
 
 
@@ -83,6 +84,7 @@ def db_artefact_metadata_to_dict(
             if artefact_metadata.discovery_date
             else None
         ),
+        'allowed_processing_time': artefact_metadata.allowed_processing_time,
     }
 
 

--- a/issue_replicator/__main__.py
+++ b/issue_replicator/__main__.py
@@ -113,21 +113,19 @@ def _iter_findings_with_processing_dates(
 
         categorisation = finding_cfg.categorisation_by_id(finding.severity)
 
-        if (allowed_processing_time := categorisation.allowed_processing_time) is None:
+        if not (due_date := categorisation.effective_due_date(
+            finding=finding.finding,
+            rescoring=finding.rescorings[0] if finding.rescorings else None,
+        )):
             continue # finding does not have to be processed anymore
-
-        due_date = finding.finding.discovery_date + allowed_processing_time
 
         for sprint in sprints:
             if sprint >= due_date:
                 finding.due_date = sprint
                 break
         else:
-            logger.warning(
-                f'could not determine target sprint for {finding=}, will use earliest sprint'
-            )
-            # we checked that at least one sprint exists earlier
-            finding.due_date = sprints[0]
+            logger.warning(f'could not determine target sprint for {finding=})')
+            continue
 
         yield finding
 

--- a/malware/__main__.py
+++ b/malware/__main__.py
@@ -178,6 +178,7 @@ def scan_resource(
 def _iter_clamav_malware_findings(
     findings: collections.abc.Iterable[dso.model.ClamAVMalwareFinding],
     resource_node: cnudie.iter.ResourceNode,
+    malware_cfg: odg.findings.Finding,
     datasource: str = dso.model.Datasource.CLAMAV,
     datatype: str = odg.findings.FindingType.MALWARE,
 ) -> collections.abc.Generator[dso.model.ArtefactMetadata, None, None]:
@@ -197,11 +198,14 @@ def _iter_clamav_malware_findings(
     )
 
     for finding in findings:
+        categorisation = malware_cfg.categorisation_by_id(finding.severity)
+
         yield dso.model.ArtefactMetadata(
             artefact=artefact_ref,
             meta=meta,
             data=finding,
-            discovery_date=discovery_date
+            discovery_date=discovery_date,
+            allowed_processing_time=categorisation.allowed_processing_time_raw,
         )
 
 
@@ -268,6 +272,7 @@ def scan_and_upload(
             _iter_clamav_malware_findings(
                 findings=result,
                 resource_node=resource_node,
+                malware_cfg=malware_cfg,
             )
         ) + [scan_info]
     )

--- a/odg/findings.py
+++ b/odg/findings.py
@@ -141,6 +141,10 @@ class VulnerabilityFindingSelector:
     cve_score_range: MinMaxRange
 
 
+class MetaAllowedProcessingTimes(enum.StrEnum):
+    INPUT = 'input'
+
+
 class RescoringModes(enum.StrEnum):
     MANUAL = 'manual'
     AUTOMATIC = 'automatic'
@@ -177,7 +181,7 @@ class FindingCategorisation:
     id: str
     display_name: str
     value: int
-    allowed_processing_time: str | int | None
+    allowed_processing_time: MetaAllowedProcessingTimes | str | int | None
     rescoring: RescoringModes | list[RescoringModes] | None
     selector: (
         CryptoFindingSelector
@@ -190,7 +194,10 @@ class FindingCategorisation:
     )
 
     def __post_init__(self):
-        if self.allowed_processing_time is not None:
+        if (
+            not isinstance(self.allowed_processing_time, MetaAllowedProcessingTimes)
+            and self.allowed_processing_time is not None
+        ):
             self.allowed_processing_time = util.convert_to_timedelta(self.allowed_processing_time)
 
         if isinstance(self.rescoring, RescoringModes):

--- a/odg/findings.py
+++ b/odg/findings.py
@@ -274,18 +274,18 @@ class FindingIssues:
     def issue_id(
         self,
         artefact: dso.model.ComponentArtefactId,
-        latest_processing_date: datetime.date,
+        due_date: datetime.date,
         version: str='v1',
     ) -> str:
         '''
         The issue-id (fka. correlation-id) is built from the grouping relevant properties of the
-        `artefact` as well as the `latest_processing_date`. It is intended to be used to reference a
-        GitHub issue to distinguish between issues "managed" by the Open-Delivery-Gear vs. those
-        manually "managed". Also, a version prefix is added to be able to differentiate issue-ids in
-        case their calculation changes in the future.
+        `artefact` as well as the `due_date`. It is intended to be used to reference a GitHub issue
+        to distinguish between issues "managed" by the Open-Delivery-Gear vs. those manually
+        "managed". Also, a version prefix is added to be able to differentiate issue-ids in case
+        their calculation changes in the future.
         '''
         group_id = self.group_id_for_artefact(artefact)
-        digest_str = group_id + latest_processing_date.isoformat()
+        digest_str = group_id + due_date.isoformat()
         digest = hashlib.shake_128(digest_str.encode()).hexdigest(length=23)
 
         return f'{version}/{digest}'

--- a/osid_extension/__main__.py
+++ b/osid_extension/__main__.py
@@ -255,6 +255,7 @@ def create_artefact_metadata(
             eol_date=eol_date,
         ),
         discovery_date=time_now.date(),
+        allowed_processing_time=categorisation.allowed_processing_time_raw,
     )
 
 

--- a/rescore/utility.py
+++ b/rescore/utility.py
@@ -288,6 +288,7 @@ def rescoring_for_sast_finding(
             severity=rescored_categorisation.id,
             user=user,
             matching_rules=[rule.name for rule in matching_rules],
-            comment='Automatically rescored based on rules.',
+            comment='Automatically rescored due_date on rules.',
+            allowed_processing_time=rescored_categorisation.allowed_processing_time_raw,
         ),
     )

--- a/sast.py
+++ b/sast.py
@@ -110,6 +110,7 @@ def create_missing_linter_finding(
             sub_type=sub_type,
         ),
         discovery_date=creation_timestamp.date(),
+        allowed_processing_time=categorisation.allowed_processing_time_raw,
     )
 
 
@@ -145,7 +146,7 @@ def iter_sast_artefacts_for_sub_type(
         categorisation=categorisation,
         user=dso.model.User(
             username='sast-extension-auto-rescoring',
-            type='sast-extension-user'
+            type='sast-extension-user',
         ),
         creation_timestamp=creation_timestamp,
     )


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
`due_date` (fka. `latest_processing_date`) is now stored as part of findings + rescorings
```
```noteworthy user
categorisations which require a user input for `due_date` are now supported
```
