### PR TITLE
Use digest-based data-key as GitHub label to adhere to GitHub limits

### DIFF
--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -4,6 +4,7 @@ import dataclasses
 import enum
 import datetime
 import functools
+import hashlib
 import json
 import logging
 import re
@@ -24,6 +25,7 @@ import delivery.client
 import delivery.model
 import dso.model
 import github.compliance.milestone as gcmi
+import github.limits
 import github.retry
 import github.user
 import github.util
@@ -1306,15 +1308,26 @@ def _create_or_update_or_close_issue_per_finding(
 ):
     processed_issues = set()
     for finding in findings:
-
         data = finding.finding.data
-        finding_labels = labels | {
-            data.key,
-        }
+
+        data_digest = hashlib.shake_128(
+            data.key.encode(),
+            usedforsecurity=False,
+        ).hexdigest(length=github.limits.label / 2)
+
+        finding_labels = labels | {data_digest}
+
+        if len(data.key) <= github.limits.label:
+            # XXX required for backwards compatibility, remove once all existing issues have the
+            # digest-based data key label set
+            finding_labels |= {data.key}
+            labels_for_filtering = (issue_id, finding_cfg.type, data.key)
+        else:
+            labels_for_filtering = (issue_id, finding_cfg.type, data_digest)
 
         finding_issues = filter_issues_for_labels(
             issues=issues,
-            labels=(issue_id, finding_cfg.type, data.key),
+            labels=labels_for_filtering,
         )
         processed_issues.update(finding_issues)
 

--- a/odg/findings.py
+++ b/odg/findings.py
@@ -349,7 +349,10 @@ class FindingIssues:
         '''
         group_id = self.group_id_for_artefact(artefact)
         digest_str = group_id + due_date.isoformat()
-        digest = hashlib.shake_128(digest_str.encode()).hexdigest(length=23)
+        digest = hashlib.shake_128(
+            digest_str.encode(),
+            usedforsecurity=False,
+        ).hexdigest(length=23)
 
         return f'{version}/{digest}'
 


### PR DESCRIPTION
**What this PR does / why we need it**:
For now, use still the raw data key in case it does not exceed GitHub's limitations to ensure backwards compatibility. Once all existing GitHub issues also have the digest-based label attached, this code path can be removed again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Use digest-based data-key as GitHub label instead of raw data-key
```
