### PR TITLE
Only ever create one compliance snapshot per artefact

### DIFF
--- a/artefact_enumerator.py
+++ b/artefact_enumerator.py
@@ -27,25 +27,8 @@ ci.log.configure_default_logging()
 k8s.logging.configure_kubernetes_logging()
 
 
-def sprint_dates(
-    delivery_client: delivery.client.DeliveryServiceClient,
-    date_name: str='release_decision',
-) -> tuple[datetime.date]:
-    sprints = delivery_client.sprints()
-    sprint_dates = tuple(
-        sprint.find_sprint_date(name=date_name).value.date()
-        for sprint in sprints
-    )
-
-    if not sprint_dates:
-        raise ValueError('no sprints found')
-
-    return sprint_dates
-
-
 def create_compliance_snapshot(
     artefact: odg.model.ComponentArtefactId,
-    due_date: datetime.date,
     now: datetime.datetime=datetime.datetime.now(),
     today: datetime.date=datetime.date.today(),
 ) -> odg.model.ArtefactMetadata:
@@ -57,7 +40,6 @@ def create_compliance_snapshot(
     )
 
     data = odg.model.ComplianceSnapshot(
-        due_date=due_date,
         state=[odg.model.ComplianceSnapshotState(
             timestamp=now,
             status=odg.model.ComplianceSnapshotStatuses.ACTIVE,
@@ -111,52 +93,37 @@ def _iter_ocm_artefacts(
                 )
 
 
-def _create_and_update_compliance_snapshots_of_artefact(
+def _create_or_update_compliance_snapshot_of_artefact(
     artefact: odg.model.ComponentArtefactId,
-    compliance_snapshots: list[odg.model.ArtefactMetadata],
-    sprints: tuple[datetime.date],
+    compliance_snapshot: odg.model.ArtefactMetadata | None,
     now: datetime.datetime=datetime.datetime.now(),
     today: datetime.date=datetime.date.today(),
-) -> tuple[list[odg.model.ArtefactMetadata], bool]:
-    update_is_required = False
-
-    for sprint_date in sprints:
-        if any(
-            compliance_snapshot for compliance_snapshot in compliance_snapshots
-            if compliance_snapshot.data.due_date == sprint_date
-        ):
-            # compliance snapshot already exists for this artefact for this sprint
-            continue
-
-        compliance_snapshots.append(create_compliance_snapshot(
+) -> odg.model.ArtefactMetadata:
+    if not compliance_snapshot:
+        logger.info(f'creating compliance snapshot for {artefact=}')
+        return create_compliance_snapshot(
             artefact=artefact,
-            due_date=sprint_date,
             now=now,
             today=today,
+        )
+
+    if (
+        compliance_snapshot.data.current_state().status !=
+        odg.model.ComplianceSnapshotStatuses.ACTIVE
+    ):
+        logger.info(f'updating state of compliance snapshot for {artefact=}')
+        compliance_snapshot.data.state.append(odg.model.ComplianceSnapshotState(
+            timestamp=now,
+            status=odg.model.ComplianceSnapshotStatuses.ACTIVE,
         ))
-        update_is_required = True
+        compliance_snapshot.data.purge_old_states()
 
-    if update_is_required:
-        logger.info(f'created compliance snapshots for {artefact=}')
-
-    for compliance_snapshot in compliance_snapshots:
-        if (
-            compliance_snapshot.data.current_state().status !=
-            odg.model.ComplianceSnapshotStatuses.ACTIVE
-        ):
-            compliance_snapshot.data.state.append(odg.model.ComplianceSnapshotState(
-                timestamp=now,
-                status=odg.model.ComplianceSnapshotStatuses.ACTIVE,
-            ))
-            compliance_snapshot.data.purge_old_states()
-            update_is_required = True
-
-    return compliance_snapshots, update_is_required
+    return compliance_snapshot
 
 
 def _calculate_backlog_item_priority(
     service: odg.extensions_cfg.Services,
-    compliance_snapshots: list[odg.model.ArtefactMetadata],
+    compliance_snapshot: odg.model.ArtefactMetadata,
     interval: int,
     now: datetime.datetime=datetime.datetime.now(),
     status: int | None=None,
@@ -166,39 +133,34 @@ def _calculate_backlog_item_priority(
     - compliance snapshot was just created -> priority HIGH
     - compliance snapshot status has changed -> priority HIGH
     '''
-    priority = k8s.backlog.BacklogPriorities.NONE
+    current_state = compliance_snapshot.data.current_state(
+        service=service,
+    )
 
-    for compliance_snapshot in compliance_snapshots:
-        current_state = compliance_snapshot.data.current_state(
-            service=service,
-        )
+    if not current_state or (status and status != current_state.status):
+        return k8s.backlog.BacklogPriorities.HIGH
 
-        if not current_state or (status and status != current_state.status):
-            priority = max(priority, k8s.backlog.BacklogPriorities.HIGH)
-            # the priority won't change anymore in this loop -> early exit
-            break
+    elif now - current_state.timestamp >= datetime.timedelta(
+        seconds=interval,
+    ):
+        return k8s.backlog.BacklogPriorities.LOW
 
-        elif now - current_state.timestamp >= datetime.timedelta(
-            seconds=interval,
-        ):
-            priority = max(priority, k8s.backlog.BacklogPriorities.LOW)
-
-    return priority
+    return k8s.backlog.BacklogPriorities.NONE
 
 
 def _create_backlog_item(
     namespace: str,
     kubernetes_api: k8s.util.KubernetesApi,
     artefact: odg.model.ComponentArtefactId,
-    compliance_snapshots: list[odg.model.ArtefactMetadata],
+    compliance_snapshot: odg.model.ArtefactMetadata,
     service: odg.extensions_cfg.Services,
     interval_seconds: int,
     now: datetime.datetime=datetime.datetime.now(),
     status: int | None=None,
-) -> tuple[list[odg.model.ArtefactMetadata], bool]:
+) -> odg.model.ArtefactMetadata:
     priority = _calculate_backlog_item_priority(
         service=service,
-        compliance_snapshots=compliance_snapshots,
+        compliance_snapshot=compliance_snapshot,
         interval=interval_seconds,
         now=now,
         status=status,
@@ -206,21 +168,18 @@ def _create_backlog_item(
 
     if not priority:
         # no need to create a backlog item for this artefact
-        return compliance_snapshots, False
+        return compliance_snapshot
 
-    # there is a need to create a new backlog item, thus update the state for every compliance
-    # snapshot of this artefact so that the configured interval can be acknowledged correctly;
-    # otherwise, the trigger might happen to often because the state of some compliance snapshots
-    # for the artefact might not have changed
-    for compliance_snapshot in compliance_snapshots:
-        compliance_snapshot.data.state.append(odg.model.ComplianceSnapshotState(
-            timestamp=now,
-            status=status,
-            service=service,
-        ))
-        compliance_snapshot.data.purge_old_states(
-            service=service,
-        )
+    # there is a need to create a new backlog item, thus update the state of the compliance snapshot
+    # of this artefact so that the configured interval can be acknowledged correctly
+    compliance_snapshot.data.state.append(odg.model.ComplianceSnapshotState(
+        timestamp=now,
+        status=status,
+        service=service,
+    ))
+    compliance_snapshot.data.purge_old_states(
+        service=service,
+    )
 
     was_created = k8s.backlog.create_unique_backlog_item(
         service=service,
@@ -232,20 +191,20 @@ def _create_backlog_item(
     if was_created:
         logger.info(f'created {service} backlog item with {priority=} for {artefact=}')
 
-    return compliance_snapshots, True
+    return compliance_snapshot
 
 
 def _create_backlog_item_for_extension(
     finding_cfgs: collections.abc.Iterable[odg.findings.Finding],
     finding_types: collections.abc.Sequence[odg.model.Datatype],
     artefact: odg.model.ComponentArtefactId,
-    compliance_snapshots: list[odg.model.ArtefactMetadata],
+    compliance_snapshot: odg.model.ArtefactMetadata,
     service: odg.extensions_cfg.Services,
     interval_seconds: int,
     namespace: str,
     kubernetes_api: k8s.util.KubernetesApi,
     now: datetime.datetime=datetime.datetime.now(),
-) -> tuple[list[odg.model.ArtefactMetadata], bool]:
+) -> odg.model.ArtefactMetadata:
     if not any(
         finding_cfg for finding_cfg in finding_cfgs
         if (
@@ -254,35 +213,33 @@ def _create_backlog_item_for_extension(
         )
     ):
         # findings are filtered out for this artefact anyways -> no need to create a BLI
-        return compliance_snapshots, False
+        return compliance_snapshot
 
     return _create_backlog_item(
         namespace=namespace,
         kubernetes_api=kubernetes_api,
         artefact=artefact,
-        compliance_snapshots=compliance_snapshots,
+        compliance_snapshot=compliance_snapshot,
         service=service,
         interval_seconds=interval_seconds,
         now=now,
     )
 
 
-def _process_compliance_snapshots_of_artefact(
+def _process_compliance_snapshot_of_artefact(
     extensions_cfg: odg.extensions_cfg.ExtensionsConfiguration,
     finding_cfgs: collections.abc.Sequence[odg.findings.Finding],
     namespace: str,
     kubernetes_api: k8s.util.KubernetesApi,
     delivery_client: delivery.client.DeliveryServiceClient,
     artefact: odg.model.ComponentArtefactId,
-    compliance_snapshots: list[odg.model.ArtefactMetadata],
-    sprints: tuple[datetime.date],
+    compliance_snapshot: odg.model.ArtefactMetadata | None,
     now: datetime.datetime=datetime.datetime.now(),
     today: datetime.date=datetime.date.today(),
 ):
-    compliance_snapshots, metadata_update_required = _create_and_update_compliance_snapshots_of_artefact( # noqa: E501
+    compliance_snapshot = _create_or_update_compliance_snapshot_of_artefact(
         artefact=artefact,
-        compliance_snapshots=compliance_snapshots,
-        sprints=sprints,
+        compliance_snapshot=compliance_snapshot,
         now=now,
         today=today,
     )
@@ -292,57 +249,54 @@ def _process_compliance_snapshots_of_artefact(
         and extensions_cfg.bdba.enabled
         and extensions_cfg.bdba.is_supported(artefact_kind=artefact.artefact_kind)
     ):
-        compliance_snapshots, snapshots_have_changed = _create_backlog_item_for_extension(
+        compliance_snapshot = _create_backlog_item_for_extension(
             finding_cfgs=finding_cfgs,
             finding_types=(
                 odg.model.Datatype.VULNERABILITY_FINDING,
                 odg.model.Datatype.LICENSE_FINDING,
             ),
             artefact=artefact,
-            compliance_snapshots=compliance_snapshots,
+            compliance_snapshot=compliance_snapshot,
             service=odg.extensions_cfg.Services.BDBA,
             interval_seconds=extensions_cfg.bdba.interval,
             namespace=namespace,
             kubernetes_api=kubernetes_api,
             now=now,
         )
-        metadata_update_required |= snapshots_have_changed
 
     if (
         extensions_cfg.clamav
         and extensions_cfg.clamav.enabled
         and extensions_cfg.clamav.is_supported(artefact_kind=artefact.artefact_kind)
     ):
-        compliance_snapshots, snapshots_have_changed = _create_backlog_item_for_extension(
+        compliance_snapshot = _create_backlog_item_for_extension(
             finding_cfgs=finding_cfgs,
             finding_types=(odg.model.Datatype.MALWARE_FINDING,),
             artefact=artefact,
-            compliance_snapshots=compliance_snapshots,
+            compliance_snapshot=compliance_snapshot,
             service=odg.extensions_cfg.Services.CLAMAV,
             interval_seconds=extensions_cfg.clamav.interval,
             namespace=namespace,
             kubernetes_api=kubernetes_api,
             now=now,
         )
-        metadata_update_required |= snapshots_have_changed
 
     if (
         extensions_cfg.crypto
         and extensions_cfg.crypto.enabled
         and extensions_cfg.crypto.is_supported(artefact_kind=artefact.artefact_kind)
     ):
-        compliance_snapshots, snapshots_have_changed = _create_backlog_item_for_extension(
+        compliance_snapshot = _create_backlog_item_for_extension(
             finding_cfgs=finding_cfgs,
             finding_types=(odg.model.Datatype.CRYPTO_FINDING,),
             artefact=artefact,
-            compliance_snapshots=compliance_snapshots,
+            compliance_snapshot=compliance_snapshot,
             service=odg.extensions_cfg.Services.CRYPTO,
             interval_seconds=extensions_cfg.crypto.interval,
             namespace=namespace,
             kubernetes_api=kubernetes_api,
             now=now,
         )
-        metadata_update_required |= snapshots_have_changed
 
     if (
         extensions_cfg.issue_replicator
@@ -354,80 +308,67 @@ def _process_compliance_snapshots_of_artefact(
             type=odg.model.Datatype.ARTEFACT_SCAN_INFO,
         ))
 
-        compliance_snapshots, snapshots_have_changed = _create_backlog_item(
+        compliance_snapshot = _create_backlog_item(
             namespace=namespace,
             kubernetes_api=kubernetes_api,
             artefact=artefact,
-            compliance_snapshots=compliance_snapshots,
+            compliance_snapshot=compliance_snapshot,
             service=odg.extensions_cfg.Services.ISSUE_REPLICATOR,
             interval_seconds=extensions_cfg.issue_replicator.interval,
             now=now,
             status=scan_count,
         )
-        metadata_update_required |= snapshots_have_changed
 
     if (
         extensions_cfg.responsibles
         and extensions_cfg.responsibles.enabled
     ):
-        compliance_snapshots, snapshots_have_changed = _create_backlog_item(
+        compliance_snapshot = _create_backlog_item(
             namespace=namespace,
             kubernetes_api=kubernetes_api,
             artefact=artefact,
-            compliance_snapshots=compliance_snapshots,
+            compliance_snapshot=compliance_snapshot,
             service=odg.extensions_cfg.Services.RESPONSIBLES,
             interval_seconds=extensions_cfg.responsibles.interval,
             now=now,
         )
-        metadata_update_required |= snapshots_have_changed
 
     if (
         extensions_cfg.sast
         and extensions_cfg.sast.enabled
         and extensions_cfg.sast.is_supported(artefact_kind=artefact.artefact_kind)
     ):
-        compliance_snapshots, snapshots_have_changed = _create_backlog_item_for_extension(
+        compliance_snapshot = _create_backlog_item_for_extension(
             finding_cfgs=finding_cfgs,
             finding_types=(odg.model.Datatype.SAST_FINDING,),
             artefact=artefact,
-            compliance_snapshots=compliance_snapshots,
+            compliance_snapshot=compliance_snapshot,
             service=odg.extensions_cfg.Services.SAST,
             interval_seconds=extensions_cfg.sast.interval,
             namespace=namespace,
             kubernetes_api=kubernetes_api,
             now=now,
         )
-        metadata_update_required |= snapshots_have_changed
 
     if (
         extensions_cfg.osid
         and extensions_cfg.osid.enabled
         and extensions_cfg.osid.is_supported(artefact_kind=artefact.artefact_kind)
     ):
-        compliance_snapshots, snapshots_have_changed = _create_backlog_item_for_extension(
+        compliance_snapshot = _create_backlog_item_for_extension(
             finding_cfgs=finding_cfgs,
             finding_types=(odg.model.Datatype.OSID_FINDING,),
             artefact=artefact,
-            compliance_snapshots=compliance_snapshots,
+            compliance_snapshot=compliance_snapshot,
             service=odg.extensions_cfg.Services.OSID,
             interval_seconds=extensions_cfg.osid.interval,
             namespace=namespace,
             kubernetes_api=kubernetes_api,
             now=now,
         )
-        metadata_update_required |= snapshots_have_changed
 
-    if not metadata_update_required:
-        logger.info(
-            f'{len(compliance_snapshots)} compliance snapshots did not change, '
-            f'no need to update in delivery-db ({artefact=})'
-        )
-        return
-
-    delivery_client.update_metadata(data=compliance_snapshots)
-    logger.info(
-        f'updated {len(compliance_snapshots)} compliance snapshots in delivery-db ({artefact=})'
-    )
+    delivery_client.update_metadata(data=[compliance_snapshot])
+    logger.info(f'updated compliance snapshot in delivery-db ({artefact=})')
 
 
 def _process_inactive_compliance_snapshots(
@@ -438,39 +379,25 @@ def _process_inactive_compliance_snapshots(
     compliance_snapshots: list[odg.model.ArtefactMetadata],
     now: datetime.datetime=datetime.datetime.now(),
 ):
-    cs_by_artefact = collections.defaultdict(list)
+    cs_by_artefact: dict[odg.model.ComponentArtefactId, odg.model.ArtefactMetadata] = {}
+    deletable_compliance_snapshots: list[odg.model.ArtefactMetadata] = []
 
     for compliance_snapshot in compliance_snapshots:
-        cs_by_artefact[compliance_snapshot.artefact].append(compliance_snapshot)
+        cs_by_artefact[compliance_snapshot.artefact] = compliance_snapshot
 
-    for compliance_snapshots in cs_by_artefact.values():
-        artefact = compliance_snapshots[0].artefact
-        update_is_required = False
-        deletable_compliance_snapshots: list[odg.model.ArtefactMetadata] = []
+    for artefact, compliance_snapshot in cs_by_artefact.items():
+        current_general_state = compliance_snapshot.data.current_state()
 
-        for compliance_snapshot in compliance_snapshots:
-            current_general_state = compliance_snapshot.data.current_state()
-
-            if current_general_state.status != odg.model.ComplianceSnapshotStatuses.INACTIVE:
-                compliance_snapshot.data.state.append(odg.model.ComplianceSnapshotState(
-                    timestamp=now,
-                    status=odg.model.ComplianceSnapshotStatuses.INACTIVE,
-                ))
-                compliance_snapshot.data.purge_old_states()
-                current_general_state = compliance_snapshot.data.current_state()
-                update_is_required = True
-
-            if now - current_general_state.timestamp >= datetime.timedelta(
-                seconds=extensions_cfg.artefact_enumerator.compliance_snapshot_grace_period,
-            ):
-                deletable_compliance_snapshots.append(compliance_snapshot)
-
-        if update_is_required:
-            delivery_client.update_metadata(data=compliance_snapshots)
-            logger.info(
-                f'updated {len(compliance_snapshots)} inactive compliance snapshots in delivery-db '
-                f'({artefact=})'
+        if current_general_state.status != odg.model.ComplianceSnapshotStatuses.INACTIVE:
+            current_general_state = odg.model.ComplianceSnapshotState(
+                timestamp=now,
+                status=odg.model.ComplianceSnapshotStatuses.INACTIVE,
             )
+            compliance_snapshot.data.state.append(current_general_state)
+            compliance_snapshot.data.purge_old_states()
+
+            delivery_client.update_metadata(data=[compliance_snapshot])
+            logger.info(f'updated inactive compliance snapshot in delivery-db ({artefact=})')
 
             if extensions_cfg.issue_replicator:
                 priority = k8s.backlog.BacklogPriorities.HIGH
@@ -487,12 +414,19 @@ def _process_inactive_compliance_snapshots(
                         f'{artefact=}'
                     )
 
-        if deletable_compliance_snapshots:
-            delivery_client.delete_metadata(data=deletable_compliance_snapshots)
-            logger.info(
-                f'deleted {len(deletable_compliance_snapshots)} inactive compliance snapshots in '
-                f'delivery-db ({artefact=})'
-            )
+        if now - current_general_state.timestamp >= datetime.timedelta(
+            seconds=extensions_cfg.artefact_enumerator.compliance_snapshot_grace_period,
+        ):
+            deletable_compliance_snapshots.append(compliance_snapshot)
+
+    if not deletable_compliance_snapshots:
+        return
+
+    delivery_client.delete_metadata(data=deletable_compliance_snapshots)
+    logger.info(
+        f'deleted {len(deletable_compliance_snapshots)} inactive compliance snapshots in '
+        f'delivery-db ({artefact=})'
+    )
 
 
 def enumerate_artefacts(
@@ -517,14 +451,6 @@ def enumerate_artefacts(
     # store current date + time to ensure they are consistent for whole enumeration
     now = datetime.datetime.now()
     today = datetime.date.today()
-
-    time_range = extensions_cfg.artefact_enumerator.sprints_relative_time_range
-    logger.info(f'{time_range=}')
-    sprints = tuple(
-        date for date in sprint_dates(delivery_client=delivery_client)
-        if not time_range or (date >= time_range.start_date and date <= time_range.end_date)
-    )
-    logger.info(f'{len(sprints)=}')
 
     ocm_artefacts = set(_iter_ocm_artefacts(
         components=extensions_cfg.artefact_enumerator.components,
@@ -564,21 +490,19 @@ def enumerate_artefacts(
     )
     logger.info(f'{len(inactive_compliance_snapshots)=}')
 
-    for artefact in artefacts:
-        compliance_snapshots = [
-            compliance_snapshot for compliance_snapshot in active_compliance_snapshots
-            if compliance_snapshot.artefact == artefact
-        ]
+    active_cs_by_artefact: dict[odg.model.ComponentArtefactId, odg.model.ArtefactMetadata] = {}
+    for compliance_snapshot in active_compliance_snapshots:
+        active_cs_by_artefact[compliance_snapshot.artefact] = compliance_snapshot
 
-        _process_compliance_snapshots_of_artefact(
+    for artefact in artefacts:
+        _process_compliance_snapshot_of_artefact(
             extensions_cfg=extensions_cfg,
             finding_cfgs=finding_cfgs,
             namespace=namespace,
             kubernetes_api=kubernetes_api,
             delivery_client=delivery_client,
             artefact=artefact,
-            compliance_snapshots=compliance_snapshots,
-            sprints=sprints,
+            compliance_snapshot=active_cs_by_artefact.get(artefact),
             now=now,
             today=today,
         )

--- a/local-setup/kind/cluster/values-bootstrapping.yaml
+++ b/local-setup/kind/cluster/values-bootstrapping.yaml
@@ -6,9 +6,6 @@ extensions_cfg:
     components:
       - component_name: ocm.software/ocm-gear
       - component_name: ocm.software/ocmcli
-    sprints_relative_time_range:
-      days_from: -90
-      days_to: 150
   bdba:
     enabled: False # disable in default because of missing BDBA credentials
     mappings:

--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -1,6 +1,5 @@
 import collections.abc
 import dataclasses
-import datetime
 import enum
 import functools
 import logging
@@ -96,31 +95,12 @@ class Component:
         )
 
 
-@dataclasses.dataclass
-class TimeRange:
-    days_from: int = -90
-    days_to: int = 150
-
-    @property
-    def start_date(self) -> datetime.date:
-        today = datetime.date.today()
-        return today + datetime.timedelta(days=self.days_from)
-
-    @property
-    def end_date(self) -> datetime.date:
-        today = datetime.date.today()
-        return today + datetime.timedelta(days=self.days_to)
-
-
 @dataclasses.dataclass(kw_only=True)
 class ArtefactEnumeratorConfig(ExtensionCfgMixins):
     '''
     :param str delivery_service_url
     :param list[Component] components:
         Components which are classified as "active" and for which compliance snapshots are created.
-    :param TimeRange sprints_relative_time_range:
-        Earliest start and latest end date for which compliance snapshots should be created. If not
-        set, all available sprints will be considered.
     :param int compliance_snapshot_grace_period:
         Time after which inactive compliance snapshots are deleted from the delivery-db. During this
         period, the inactive snapshots are used to possibly close outdated GitHub issues (i.e. the
@@ -132,7 +112,6 @@ class ArtefactEnumeratorConfig(ExtensionCfgMixins):
     service: Services = Services.ARTEFACT_ENUMERATOR
     delivery_service_url: str
     components: list[Component]
-    sprints_relative_time_range: TimeRange | None
     compliance_snapshot_grace_period: int = 60 * 60 * 24 # 24h
     schedule: str = '*/5 * * * *' # every 5 minutes
     successful_jobs_history_limit: int = 1

--- a/odg/model.py
+++ b/odg/model.py
@@ -801,6 +801,20 @@ class ComplianceSnapshotState:
 class ComplianceSnapshot:
     state: list[ComplianceSnapshotState]
 
+    @property
+    def is_active(self) -> bool:
+        if not (state := self.current_state()):
+            return False
+
+        return state.status is ComplianceSnapshotStatuses.ACTIVE
+
+    def update_state(
+        self,
+        state: ComplianceSnapshotState,
+    ):
+        self.state.append(state)
+        self._purge_old_states(service=state.service)
+
     def current_state(
         self,
         service: str | None=None,
@@ -810,7 +824,7 @@ class ComplianceSnapshot:
                 return state
         return None
 
-    def purge_old_states(
+    def _purge_old_states(
         self,
         service: str | None=None,
     ):

--- a/odg/model.py
+++ b/odg/model.py
@@ -799,16 +799,11 @@ class ComplianceSnapshotState:
 
 @dataclasses.dataclass
 class ComplianceSnapshot:
-    due_date: datetime.date
     state: list[ComplianceSnapshotState]
-
-    @property
-    def key(self) -> str:
-        return self.due_date.isoformat()
 
     def current_state(
         self,
-        service: str = None,
+        service: str | None=None,
     ) -> ComplianceSnapshotState | None:
         for state in sorted(self.state, key=lambda s: s.timestamp, reverse=True):
             if service == state.service:
@@ -817,11 +812,11 @@ class ComplianceSnapshot:
 
     def purge_old_states(
         self,
-        service: str = None,
+        service: str | None=None,
     ):
         current_state = None
         for state in sorted(self.state, key=lambda s: s.timestamp, reverse=True):
-            if not service == state.service:
+            if service != state.service:
                 continue
 
             if not current_state:

--- a/odg/model.py
+++ b/odg/model.py
@@ -332,7 +332,7 @@ class ResponsibleAssigneeModes(enum.StrEnum):
     SKIP = 'skip'
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class Metadata:
     datasource: str
     type: str
@@ -366,7 +366,7 @@ class OperatingSystemId:
         return self.PRETTY_NAME == 'Distroless'
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class BDBAMixin:
     package_name: str
     package_version: str | None # bdba might be unable to determine a version
@@ -376,24 +376,24 @@ class BDBAMixin:
     group_id: int
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class License:
     name: str
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class FilesystemPathEntry:
     path: str
     type: str
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class FilesystemPath:
     path: list[FilesystemPathEntry]
     digest: str
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class StructureInfo(BDBAMixin):
     licenses: list[License]
     filesystem_paths: list[FilesystemPath]
@@ -403,7 +403,7 @@ class StructureInfo(BDBAMixin):
         return _as_key(self.package_name, self.package_version)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class Finding:
     '''
     Base class for artefact metadata which is interpreted as a finding. "Finding" as in it has a
@@ -412,7 +412,7 @@ class Finding:
     severity: str
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class LicenseFinding(Finding, BDBAMixin):
     license: License
 
@@ -421,7 +421,7 @@ class LicenseFinding(Finding, BDBAMixin):
         return _as_key(self.package_name, self.package_version, self.license.name)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class VulnerabilityFinding(Finding, BDBAMixin):
     cve: str
     cvss_v3_score: float
@@ -433,7 +433,7 @@ class VulnerabilityFinding(Finding, BDBAMixin):
         return _as_key(self.package_name, self.package_version, self.cve)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class RescoringVulnerabilityFinding:
     package_name: str
     cve: str
@@ -443,7 +443,7 @@ class RescoringVulnerabilityFinding:
         return _as_key(self.package_name, self.cve)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class RescoringLicenseFinding:
     package_name: str
     license: License
@@ -453,7 +453,7 @@ class RescoringLicenseFinding:
         return _as_key(self.package_name, self.license.name)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class MalwareFindingDetails:
     filename: str
     content_digest: str
@@ -465,7 +465,7 @@ class MalwareFindingDetails:
         return _as_key(self.content_digest, self.filename, self.malware)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class ClamAVMalwareFinding(Finding):
     finding: MalwareFindingDetails
     octets_count: int
@@ -479,7 +479,7 @@ class ClamAVMalwareFinding(Finding):
         return self.finding.key
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class SastFinding(Finding):
     sast_status: SastStatus
     sub_type: SastSubType
@@ -489,7 +489,7 @@ class SastFinding(Finding):
         return _as_key(self.sast_status, self.sub_type)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class RescoreSastFinding:
     sast_status: SastStatus
     sub_type: SastSubType
@@ -499,7 +499,7 @@ class RescoreSastFinding:
         return _as_key(self.sast_status, self.sub_type)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class OsIdFinding(Finding):
     osid: OperatingSystemId
     os_status: OsStatus
@@ -529,7 +529,7 @@ class OsIdFinding(Finding):
             return 'Unknown OSID status'
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class RescoreOsIdFinding:
     osid: OperatingSystemId
 
@@ -538,13 +538,13 @@ class RescoreOsIdFinding:
         return _as_key(self.osid.ID)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class DikiCheck:
     message: str
     targets: list[dict] | dict
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class DikiFinding(Finding):
     provider_id: str
     ruleset_id: str
@@ -666,7 +666,7 @@ class CryptoAsset:
         return _as_key(self.asset_type, self.properties.key)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class CryptoFinding(Finding):
     standard: str
     asset: CryptoAsset
@@ -687,7 +687,7 @@ class RescoringCryptoFinding:
         return _as_key(self.standard, self.asset.key)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class InventoryFinding(Finding):
     '''
     Represents a finding from the gardener/inventory system
@@ -714,7 +714,7 @@ class InventoryFinding(Finding):
         return _as_key(self.provider_name, self.resource_kind, self.resource_name)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class User:
     username: str
     type: str = 'user'
@@ -724,7 +724,7 @@ class User:
         return _as_key(self.username, self.type)
 
 
-@dataclasses.dataclass(frozen=True, kw_only=True)
+@dataclasses.dataclass(kw_only=True)
 class BDBAUser(User):
     email: str
     firstname: str
@@ -732,7 +732,7 @@ class BDBAUser(User):
     type: str = 'bdba-user'
 
 
-@dataclasses.dataclass(frozen=True, kw_only=True)
+@dataclasses.dataclass(kw_only=True)
 class GitHubUser(User):
     github_hostname: str
     type: str = 'github-user'
@@ -744,7 +744,7 @@ class MetaRescoringRules(enum.StrEnum):
     ORIGINAL_SEVERITY = 'original-severity'
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class CustomRescoring:
     '''
     The `allowed_processing_time` is stored relatively to allow the rescoring to apply to findings
@@ -790,14 +790,14 @@ class ComplianceSnapshotStatuses(enum.StrEnum):
     INACTIVE = 'inactive'
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class ComplianceSnapshotState:
     timestamp: datetime.datetime
     status: ComplianceSnapshotStatuses | str | int | None = None
     service: str | None = None
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class ComplianceSnapshot:
     due_date: datetime.date
     state: list[ComplianceSnapshotState]
@@ -842,7 +842,7 @@ class FalcoPriority(enum.StrEnum):
     DEBUG = 'Debug'
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class FalcoEvent:
     message: str
     cluster: str
@@ -853,19 +853,19 @@ class FalcoEvent:
     output: dict[str, typing.Any]
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class Node:
     name: str
     count: int
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class Cluster:
     name: str
     nodes: list[Node]
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class FalcoEventGroup:
     '''
     FalcoEventGroup represents a group of Falco events that are similar in
@@ -903,7 +903,7 @@ class FalcoEventGroup:
         return self.group_hash
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class FalcoInteractiveEventGroup:
     '''
     Group of events that - most likely - are a result of a single interactive
@@ -937,7 +937,7 @@ class FalcoFindingSubType(enum.StrEnum):
     INTERACTIVE_EVENT_GROUP = 'interactive-event-group'
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class FalcoFinding(Finding):
     subtype: FalcoFindingSubType
     finding: FalcoInteractiveEventGroup | FalcoEventGroup
@@ -947,7 +947,7 @@ class FalcoFinding(Finding):
         return self.finding.key
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class ResponsibleInfo:
     referenced_type: Datatype
 

--- a/rescore/artefacts.py
+++ b/rescore/artefacts.py
@@ -33,7 +33,7 @@ import yp
 logger = logging.getLogger(__name__)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class LicenseFinding(odg.model.Finding):
     package_name: str
     package_versions: tuple[str, ...] # "..." for dacite.from_dict
@@ -41,7 +41,7 @@ class LicenseFinding(odg.model.Finding):
     filesystem_paths: list[odg.model.FilesystemPath]
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class VulnerabilityFinding(odg.model.Finding):
     package_name: str
     package_versions: tuple[str, ...] # "..." for dacite.from_dict
@@ -53,12 +53,12 @@ class VulnerabilityFinding(odg.model.Finding):
     filesystem_paths: list[odg.model.FilesystemPath]
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class MalwareFinding(odg.model.Finding):
     finding: odg.model.MalwareFindingDetails
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class RescoringProposal:
     finding: (
         LicenseFinding


### PR DESCRIPTION
**What this PR does / why we need it**:
Some time ago, each compliance snapshot directly correlated to a specific GitHub issue by containing the `issue_id`, fka. `correlation_id`. Since this `issue_id` also contains the `due_date`, there were one compliance snapshot for each sprint for each artefact.
Ever since the `issue_id` is not stored anymore directly in the compliance snapshots, but calculated ad-hoc by the issue-replicator using the provided configuration, the only purpose of the compliance snapshots is to store the states of the individual extensions (e.g. when they were executed the last time).
Since this information was stored redundantly among all compliance snapshots of an artefact anyways, it is now possible to store only _one_ compliance snapshot per artefact containing all extension states. This will reduce the required amount of compliance snapshots drastically, thus reducing spent time on networking as well as unnecessary nested loops.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Only create one compliance snapshot per artefact (requires one-time purging of existing compliance snapshots)
```
