### PR TITLE
Do not hardcode nginx ingress

### DIFF
--- a/charts/delivery-service/templates/service-ingress.yaml
+++ b/charts/delivery-service/templates/service-ingress.yaml
@@ -4,19 +4,11 @@ metadata:
   name: delivery-service
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
   annotations:
-    cert.gardener.cloud/purpose: managed
-    dns.gardener.cloud/class: garden
-    dns.gardener.cloud/dnsnames: "*"
-    nginx.ingress.kubernetes.io/proxy-body-size: 8m
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
-    nginx.ingress.kubernetes.io/proxy-next-upstream: error timeout http_503
-    nginx.ingress.kubernetes.io/proxy-next-upstream-timeout: "0"
-    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "0"
     {{- range $annotation, $value := default dict .Values.ingress.annotations }}
     {{ $annotation }}: {{ $value }}
     {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ default "nginx" .Values.ingress.class }}
   rules:
   {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}

--- a/local-setup/kind/cluster/values-delivery-service.yaml
+++ b/local-setup/kind/cluster/values-delivery-service.yaml
@@ -1,5 +1,11 @@
 ingress:
   class: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 8m
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '"900"'
+    nginx.ingress.kubernetes.io/proxy-next-upstream: error timeout http_503
+    nginx.ingress.kubernetes.io/proxy-next-upstream-timeout: '"0"'
+    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: '"0"'
   disableTls: True
   hosts:
     - delivery-service


### PR DESCRIPTION
We removed ingress controller flexibility as a preparation for a managed offering. While we still want to offer a lightweight out-of-the-box expierence, it is required to support more sophisticated use-cases which consume the helm charts directly.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Ingress controller class name of delivery-service can now be overwritten
```
