### PR TITLE
Increase `CommandReadTimeout` for ClamAV

### DIFF
--- a/clamd.conf
+++ b/clamd.conf
@@ -10,3 +10,4 @@ MaxFileSize 0
 MaxRecursion 0
 MaxFiles 0
 AlertExceedsMax yes
+CommandReadTimeout 15


### PR DESCRIPTION
defaults to 5, see:
https://linux.die.net/man/5/clamd.conf

As content is passed as generator, it is only resolved after socket connection was establised. Content is not always streamed, thus especially for large files this timeout is relevant.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
ClamAV (Malware Scans) "CommandReadTimeout" was increased
```
