### PR TITLE
Define network policies

### DIFF
--- a/charts/delivery-service/templates/default-deny.yaml
+++ b/charts/delivery-service/templates/default-deny.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  # select all pods in the namespace
+  podSelector: {}
+  # deny all traffic
+  policyTypes:
+  - Ingress
+  - Egress

--- a/charts/delivery-service/templates/service-deployment.yaml
+++ b/charts/delivery-service/templates/service-deployment.yaml
@@ -1,12 +1,14 @@
+{{- $podName := "delivery-service" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: delivery-service
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      app: delivery-service
+      app: {{ $podName }}
   strategy:
     type: RollingUpdate
   template:
@@ -18,7 +20,7 @@ spec:
       {{- end }}
       {{- end }}
       labels:
-        app: delivery-service
+        app: {{ $podName }}
       {{- if default dict (.Values.pod).labels }}
       {{- range $annotation, $value := .Values.pod.labels }}
         {{ $annotation }}: {{ $value }}
@@ -31,9 +33,9 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: delivery-service
+              app: {{ $podName }}
       containers:
-        - name: delivery-service
+        - name: {{ $podName }}
           image: {{ include "image" .Values.image }}
           imagePullPolicy: IfNotPresent
           securityContext:
@@ -154,3 +156,33 @@ spec:
       {{- if .Values.additionalVolumes }}
         {{- toYaml .Values.additionalVolumes | nindent 8 }}
       {{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-delivery-service
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-delivery-service
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8080

--- a/charts/extensions/charts/artefact-enumerator/templates/artefact-enumerator.yaml
+++ b/charts/extensions/charts/artefact-enumerator/templates/artefact-enumerator.yaml
@@ -1,7 +1,9 @@
+{{- $podName := "artefact-enumerator" }}
+
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: artefact-enumerator
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   schedule: {{ default "*/5 * * * *" .Values.schedule | quote }} # schedule may contain asterisks, quote to avoid yaml parser errors
@@ -14,10 +16,10 @@ spec:
       template:
         metadata:
           labels:
-            app: artefact-enumerator
+            app: {{ $podName }}
         spec:
           containers:
-          - name: artefact-enumerator
+          - name: {{ $podName }}
             image: {{ include "image" .Values.image }}
             imagePullPolicy: IfNotPresent
             command:
@@ -79,3 +81,17 @@ spec:
               configMap:
                 name: ocm-repo-mappings
           restartPolicy: Never
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-artefact-enumerator
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port

--- a/charts/extensions/charts/backlog-controller/templates/backlog-controller.yaml
+++ b/charts/extensions/charts/backlog-controller/templates/backlog-controller.yaml
@@ -1,20 +1,22 @@
+{{- $podName := "backlog-controller" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: backlog-controller
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: backlog-controller
+      app: {{ $podName }}
   template:
     metadata:
       labels:
-        app: backlog-controller
+        app: {{ $podName }}
     spec:
       containers:
-        - name: backlog-controller
+        - name: {{ $podName }}
           image: {{ include "image" .Values.image }}
           imagePullPolicy: IfNotPresent
           command:
@@ -50,3 +52,17 @@ spec:
         - name: extensions-cfg
           configMap:
             name: extensions-cfg
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-backlog-controller
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port

--- a/charts/extensions/charts/bdba/templates/bdba.yaml
+++ b/charts/extensions/charts/bdba/templates/bdba.yaml
@@ -1,18 +1,20 @@
+{{- $podName := "bdba" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: bdba
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
     matchLabels:
-      app: bdba
+      app: {{ $podName }}
       delivery-gear.gardener.cloud/service: bdba
   template:
     metadata:
       labels:
-        app: bdba
+        app: {{ $podName }}
         delivery-gear.gardener.cloud/service: bdba
     spec:
       topologySpreadConstraints:
@@ -21,10 +23,10 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: bdba
+              app: {{ $podName }}
       terminationGracePeriodSeconds: 1800 # 30 min
       containers:
-        - name: bdba
+        - name: {{ $podName }}
           image: {{ include "image" .Values.image }}
           imagePullPolicy: IfNotPresent
           command:
@@ -102,3 +104,17 @@ spec:
         - name: ocm-repo-mappings
           configMap:
             name: ocm-repo-mappings
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-bdba
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port

--- a/charts/extensions/charts/cache-manager/templates/cache-manager.yaml
+++ b/charts/extensions/charts/cache-manager/templates/cache-manager.yaml
@@ -1,7 +1,9 @@
+{{- $podName := "cache-manager" }}
+
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: cache-manager
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   schedule: {{ default "*/10 * * * *" .Values.schedule | quote }} # schedule contains asterisks, quote to avoid yaml parser errors
@@ -14,10 +16,10 @@ spec:
       template:
         metadata:
           labels:
-            app: cache-manager
+            app: {{ $podName }}
         spec:
           containers:
-          - name: cache-manager
+          - name: {{ $podName }}
             image: {{ include "image" .Values.image }}
             imagePullPolicy: IfNotPresent
             command:
@@ -78,3 +80,17 @@ spec:
               configMap:
                 name: ocm-repo-mappings
           restartPolicy: Never
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-cache-manager
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port

--- a/charts/extensions/charts/clamav/templates/clamav.yaml
+++ b/charts/extensions/charts/clamav/templates/clamav.yaml
@@ -1,18 +1,20 @@
+{{- $podName := "clamav" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: clamav
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
     matchLabels:
-      app: clamav
+      app: {{ $podName }}
       delivery-gear.gardener.cloud/service: clamav
   template:
     metadata:
       labels:
-        app: clamav
+        app: {{ $podName }}
         delivery-gear.gardener.cloud/service: clamav
     spec:
       topologySpreadConstraints:
@@ -21,10 +23,10 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: clamav
+              app: {{ $podName }}
       terminationGracePeriodSeconds: 1800 # 30 min
       containers:
-        - name: clamav
+        - name: {{ $podName }}
           image: {{ include "image" .Values.image }}
           imagePullPolicy: IfNotPresent
           securityContext:
@@ -99,3 +101,17 @@ spec:
         - name: freshclam-config
           configMap:
             name: clamav-freshclam-config
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-clamav
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port

--- a/charts/extensions/charts/clamav/templates/freshclam.yaml
+++ b/charts/extensions/charts/clamav/templates/freshclam.yaml
@@ -1,13 +1,15 @@
+{{- $podName := "freshclam" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: freshclam
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: freshclam
+      app: {{ $podName }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -15,10 +17,10 @@ spec:
   template:
     metadata:
       labels:
-        app: freshclam
+        app: {{ $podName }}
     spec:
       containers:
-        - name: freshclam
+        - name: {{ $podName }}
           image: {{ include "image" .Values.freshclam.image }}
           imagePullPolicy: IfNotPresent
           securityContext:
@@ -45,3 +47,33 @@ spec:
             limits:
               memory: 1Gi
               cpu: 1500m
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-freshclam
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-freshclam
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8080

--- a/charts/extensions/charts/crypto/templates/crypto.yaml
+++ b/charts/extensions/charts/crypto/templates/crypto.yaml
@@ -1,18 +1,20 @@
+{{- $podName := "crypto" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: crypto
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
     matchLabels:
-      app: crypto
+      app: {{ $podName }}
       delivery-gear.gardener.cloud/service: crypto
   template:
     metadata:
       labels:
-        app: crypto
+        app: {{ $podName }}
         delivery-gear.gardener.cloud/service: crypto
     spec:
       topologySpreadConstraints:
@@ -21,10 +23,10 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: crypto
+              app: {{ $podName }}
       terminationGracePeriodSeconds: 300 # 5 min
       containers:
-        - name: crypto
+        - name: {{ $podName }}
           image: {{ include "image" .Values.image }}
           imagePullPolicy: IfNotPresent
           command:
@@ -97,3 +99,17 @@ spec:
         - name: ocm-repo-mappings
           configMap:
             name: ocm-repo-mappings
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-crypto
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port

--- a/charts/extensions/charts/delivery-db-backup/templates/delivery-db-backup.yaml
+++ b/charts/extensions/charts/delivery-db-backup/templates/delivery-db-backup.yaml
@@ -1,7 +1,9 @@
+{{- $podName := "delivery-db-backup" }}
+
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: delivery-db-backup
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   schedule: {{ default "0 0 * * *" .Values.schedule | quote }} # schedule contains asterisks, quote to avoid yaml parser errors
@@ -15,10 +17,10 @@ spec:
       template:
         metadata:
           labels:
-            app: delivery-db-backup
+            app: {{ $podName }}
         spec:
           containers:
-          - name: delivery-db-backup
+          - name: {{ $podName }}
             image: {{ include "image" .Values.image }}
             imagePullPolicy: IfNotPresent
             command:
@@ -63,3 +65,17 @@ spec:
               configMap:
                 name: extensions-cfg
           restartPolicy: Never
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-delivery-db-backup
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port

--- a/charts/extensions/charts/issue-replicator/templates/issue-replicator.yaml
+++ b/charts/extensions/charts/issue-replicator/templates/issue-replicator.yaml
@@ -1,3 +1,5 @@
+{{- $podName := "issue-replicator" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,17 +9,17 @@ spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
     matchLabels:
-      app: issue-replicator
+      app: {{ $podName }}
       delivery-gear.gardener.cloud/service: issueReplicator
   template:
     metadata:
       labels:
-        app: issue-replicator
+        app: {{ $podName }}
         delivery-gear.gardener.cloud/service: issueReplicator
     spec:
       terminationGracePeriodSeconds: 300 # 5 min
       containers:
-        - name: issue-replicator
+        - name: {{ $podName }}
           image: {{ include "image" .Values.image }}
           imagePullPolicy: IfNotPresent
           command:
@@ -84,3 +86,17 @@ spec:
         - name: ocm-repo-mappings
           configMap:
             name: ocm-repo-mappings
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-issue-replicator
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port

--- a/charts/extensions/charts/osid/templates/osid.yaml
+++ b/charts/extensions/charts/osid/templates/osid.yaml
@@ -1,18 +1,20 @@
+{{- $podName := "osid" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: osid
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
     matchLabels:
-      app: osid
+      app: {{ $podName }}
       delivery-gear.gardener.cloud/service: osid
   template:
     metadata:
       labels:
-        app: osid
+        app: {{ $podName }}
         delivery-gear.gardener.cloud/service: osid
     spec:
       topologySpreadConstraints:
@@ -21,10 +23,10 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: osid
+              app: {{ $podName }}
       terminationGracePeriodSeconds: 300 # 5 min
       containers:
-        - name: osid
+        - name: {{ $podName }}
           image: {{ include "image" .Values.image }}
           imagePullPolicy: IfNotPresent
           command:
@@ -91,3 +93,17 @@ spec:
         - name: ocm-repo-mappings
           configMap:
             name: ocm-repo-mappings
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-osid
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port

--- a/charts/extensions/charts/responsibles/templates/responsibles.yaml
+++ b/charts/extensions/charts/responsibles/templates/responsibles.yaml
@@ -1,18 +1,20 @@
+{{- $podName := "responsibles" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: responsibles
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
     matchLabels:
-      app: responsibles
+      app: {{ $podName }}
       delivery-gear.gardener.cloud/service: responsibles
   template:
     metadata:
       labels:
-        app: responsibles
+        app: {{ $podName }}
         delivery-gear.gardener.cloud/service: responsibles
     spec:
       topologySpreadConstraints:
@@ -21,10 +23,10 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: responsibles
+              app: {{ $podName }}
       terminationGracePeriodSeconds: 60
       containers:
-        - name: responsibles
+        - name: {{ $podName }}
           image: {{ include "image" .Values.image }}
           imagePullPolicy: IfNotPresent
           command:
@@ -78,3 +80,17 @@ spec:
         - name: findings-cfg
           configMap:
             name: findings-cfg
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-responsibles
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port

--- a/charts/extensions/charts/sast/templates/sast.yaml
+++ b/charts/extensions/charts/sast/templates/sast.yaml
@@ -1,18 +1,20 @@
+{{- $podName := "sast" }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sast
+  name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:
     matchLabels:
-      app: sast
+      app: {{ $podName }}
       delivery-gear.gardener.cloud/service: sast
   template:
     metadata:
       labels:
-        app: sast
+        app: {{ $podName }}
         delivery-gear.gardener.cloud/service: sast
     spec:
       topologySpreadConstraints:
@@ -21,10 +23,10 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: sast
+              app: {{ $podName }}
       terminationGracePeriodSeconds: 300 # 5 min
       containers:
-        - name: sast
+        - name: {{ $podName }}
           image: {{ include "image" .Values.image }}
           imagePullPolicy: IfNotPresent
           command:
@@ -91,3 +93,17 @@ spec:
         - name: ocm-repo-mappings
           configMap:
             name: ocm-repo-mappings
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-sast
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port


### PR DESCRIPTION
Deny all egress and ingress traffic by default.
Explicitly all traffic for certain pods.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action developer
Added network policies which deny all traffic by default. For all ODG pods requiring egress or ingress, corresponding network policy rules have been defined.
```
