### PR TITLE
Require `api_url` instead of `github_secret_name` in oauth cfg

### DIFF
--- a/local-setup/kind/cluster/values-bootstrapping.yaml
+++ b/local-setup/kind/cluster/values-bootstrapping.yaml
@@ -319,7 +319,7 @@ secrets:
     local:
       client_id: ...
       client_secret: ...
-      github_secret_name: github_com
+      api_url: https://api.github.com
       type: github
       name: GitHub
       oauth_url: https://github.com/login/oauth/authorize

--- a/middleware/auth.py
+++ b/middleware/auth.py
@@ -138,9 +138,7 @@ class OAuthCfgs(aiohttp.web.View):
               $ref: '#/definitions/AuthConfig'
         '''
         def oauth_cfg_to_dict(oauth_cfg: secret_mgmt.oauth_cfg.OAuthCfg):
-            secret_factory = self.request.app[consts.APP_SECRET_FACTORY]
-            github_cfg = secret_factory.github(oauth_cfg.github_secret_name)
-            github_host = urllib.parse.urlparse(github_cfg.api_url).hostname.lower()
+            github_host = urllib.parse.urlparse(oauth_cfg.api_url).hostname.lower()
 
             redirect_uri = util.urljoin(
                 self.request.app[consts.APP_BASE_URL],
@@ -157,9 +155,8 @@ class OAuthCfgs(aiohttp.web.View):
 
             return {
                 'name': oauth_cfg.name,
-                'github_name': oauth_cfg.github_secret_name,
                 'github_host': github_host,
-                'api_url': github_cfg.api_url,
+                'api_url': oauth_cfg.api_url,
                 'oauth_url': oauth_cfg.oauth_url,
                 'client_id': oauth_cfg.client_id,
                 'scope': oauth_cfg.scope,
@@ -271,12 +268,10 @@ class OAuthLogin(aiohttp.web.View):
 
             access_token = access_token[0]
 
-            github_cfg = secret_factory.github(oauth_cfg.github_secret_name)
-            api_url = github_cfg.api_url
+            api_url = oauth_cfg.api_url
         else:
             for oauth_cfg in feature_authentication.oauth_cfgs:
-                github_cfg = secret_factory.github(oauth_cfg.github_secret_name)
-                if github_cfg.api_url == api_url:
+                if oauth_cfg.api_url == api_url:
                     break
 
             else:

--- a/secret_mgmt/__init__.py
+++ b/secret_mgmt/__init__.py
@@ -143,7 +143,7 @@ class SecretFactory:
                         secrets_dict['oauth-cfg'][f'{delivery_cfg._name}{idx}'] = secret_mgmt.oauth_cfg.OAuthCfg( # noqa: E501
                             name=oauth_cfg['name'],
                             type=secret_mgmt.oauth_cfg.OAuthCfgTypes(oauth_cfg['type']),
-                            github_secret_name=oauth_cfg['github_cfg'],
+                            api_url=oauth_cfg['api_url'],
                             oauth_url=oauth_cfg['oauth_url'],
                             token_url=oauth_cfg['token_url'],
                             client_id=oauth_cfg['client_id'],

--- a/secret_mgmt/oauth_cfg.py
+++ b/secret_mgmt/oauth_cfg.py
@@ -32,7 +32,7 @@ class RoleBinding:
 class OAuthCfg:
     name: str
     type: OAuthCfgTypes
-    github_secret_name: str
+    api_url: str
     oauth_url: str
     token_url: str
     client_id: str


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of the oauth-flow, it is not required to use the secret referenced via `github_secret_name`, but only to retrieve its `api_url`. Hence, instead of requiring to reference a secret which will contain an `api_url`, directly reference the `api_url`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The oauth-cfg does not require a `github_secret_name` anymore but instead only an `api_url`
```
