### PR TITLE
fix: Ensure `libcrypto3` is compatible with `clamav`

### DIFF
--- a/Dockerfile.extensions.clamav
+++ b/Dockerfile.extensions.clamav
@@ -13,6 +13,7 @@ RUN --mount=type=bind,source=/dist,target=/dist \
     libc-dev \
     libffi-dev \
     python3-dev \
+&& apk add --no-cache --upgrade libcrypto3 \
 && CFLAGS='-Wno-int-conversion' \
     pip3 install --upgrade --no-cache-dir --find-links ./dist ocm-gear-extensions \
 && apk del --no-cache \


### PR DESCRIPTION
alpine edge contains an outdated version of `libcrypto3` (`3.3.2-r4`, whereas `3.5.0-r0` is latest available).
`clamav 1.4.3` is not compatible with the older version of `libcrypto3` anymore.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Ensure "libcrypto3" package is compatible to "clamav" malware scanner
```
