### PR TITLE
Allow optional clamav deployment annotations

### DIFF
--- a/charts/extensions/charts/clamav/templates/clamav.yaml
+++ b/charts/extensions/charts/clamav/templates/clamav.yaml
@@ -5,6 +5,12 @@ kind: Deployment
 metadata:
   name: {{ $podName }}
   namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+  {{- if default dict (.Values.deployment).annotations }}
+  annotations:
+  {{- range $annotation, $value := .Values.deployment.annotations }}
+    {{ $annotation }}: {{ $value }}
+  {{- end }}
+  {{- end }}
 spec:
   replicas: 0 # will be scaled automatically by backlog-controller
   selector:

--- a/charts/extensions/values.yaml
+++ b/charts/extensions/values.yaml
@@ -27,6 +27,8 @@ clamav:
   image:
     repository: null
     tag: null
+  deployment:
+    annotations: []
 crypto:
   enabled: false
   image:


### PR DESCRIPTION
Will be required for mODG, as deployment annotations are used by gardener-resource-manager to prevent rollback of scaling.

see:
https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#preserving-replicas-or-resources-in-workload-resources

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Support optional deployment annotations for ClamAV
```
