### PR TITLE
Fix: Add `absent_ok` flag for `github_repo_lookup`

### DIFF
--- a/components.py
+++ b/components.py
@@ -1002,9 +1002,10 @@ class UpgradePRs(aiohttp.web.View):
         ) -> list[dict]:
             github_repo_lookup = self.request.app[consts.APP_GITHUB_REPO_LOOKUP]
 
-            try:
-                repo = github_repo_lookup(repo_url)
-            except ValueError:
+            if not (repo := github_repo_lookup(
+                repo_url,
+                absent_ok=True,
+            )):
                 logger.warning(f'no github-cfg found for {repo_url=}')
                 return [] # matching github-cfg is optional
 

--- a/lookups.py
+++ b/lookups.py
@@ -434,7 +434,9 @@ def github_repo_lookup(
     github_api_lookup,
 ):
     def github_repo_lookup(
-        repo_url: str, /,
+        repo_url: str,
+        /,
+        absent_ok: bool=False,
     ):
         if not '://' in repo_url:
             repo_url = f'x://{repo_url}'
@@ -442,7 +444,13 @@ def github_repo_lookup(
         parsed = urllib.parse.urlparse(repo_url)
         org, repo = parsed.path.strip('/').split('/')[:2]
 
-        gh_api = github_api_lookup(repo_url)
+        gh_api = github_api_lookup(
+            repo_url,
+            absent_ok=absent_ok,
+        )
+
+        if not gh_api and absent_ok:
+            return None
 
         return gh_api.repository(org, repo)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed handling of missing GitHub configuration for upgrade pull-request retrieval
```
