### PR TITLE
Bump JWT version to `v2`

### DIFF
--- a/middleware/auth.py
+++ b/middleware/auth.py
@@ -401,7 +401,7 @@ async def set_session_and_refresh_token(
     await db_session.commit()
 
     session_token = {
-        'version': 'v1',
+        'version': 'v2',
         'iss': issuer,
         'iat': int(now.timestamp()),
         'exp': int((now + SESSION_TOKEN_MAX_AGE).timestamp()),
@@ -1132,7 +1132,7 @@ def validate_jwt_payload(decoded_jwt: dict):
     except jsonschema.exceptions.ValidationError as e:
         raise aiohttp.web.HTTPUnauthorized(text=e.message)
 
-    if (version := decoded_jwt.get('version')) and version != 'v1':
+    if (version := decoded_jwt.get('version')) and version != 'v2':
         raise aiohttp.web.HTTPUnauthorized(text='Token version does not match')
 
 

--- a/test/test_jwt_validation.py
+++ b/test/test_jwt_validation.py
@@ -16,7 +16,7 @@ JWT_ALGORITHM = 'HS256'
 def gen_jwt_payload():
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     return {
-        'version': 'v1',
+        'version': 'v2',
         'sub': 'service_user',
         'iss': ISSUER,
         'iat': int((now-datetime.timedelta(minutes=10)).timestamp()),


### PR DESCRIPTION
**What this PR does / why we need it**:
The change to session and refresh tokens together with a changed JWT payload require the existing users to be logged-out once, hence bump the JWT version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The JWT version is bumped to `v2` to ensure logging-out of users
```
