### PR TITLE
Merge  Patchlevel categories of ODG findings

### DIFF
--- a/odg/model.py
+++ b/odg/model.py
@@ -177,8 +177,7 @@ class OsStatus(enum.StrEnum):
     BRANCH_REACHED_EOL = 'branchReachedEol'
     UPDATE_AVAILABLE_FOR_BRANCH = 'updateAvailableForBranch'
     EMPTY_OS_ID = 'emptyOsId'
-    AT_MOST_ONE_PATCHLEVEL_BEHIND = 'atMostOnePatchlevelBehind'
-    MORE_THAN_ONE_PATCHLEVEL_BEHIND = 'moreThanOnePatchlevelBehind'
+    PATCHLEVEL_BEHIND = 'patchlevelBehind'
     UP_TO_DATE = 'upToDate'
     DISTROLESS = 'distroless'
 
@@ -523,10 +522,8 @@ class OsIdFinding(Finding):
     def status_description(self) -> str:
         if self.os_status is OsStatus.BRANCH_REACHED_EOL:
             return 'Branch has reached end-of-life'
-        elif self.os_status is OsStatus.MORE_THAN_ONE_PATCHLEVEL_BEHIND:
-            return 'Image is more than one patchlevel behind'
-        elif self.os_status is OsStatus.AT_MOST_ONE_PATCHLEVEL_BEHIND:
-            return 'Image is at most one patchlevel behind'
+        elif self.os_status is OsStatus.PATCHLEVEL_BEHIND:
+            return 'Image is one or more patchlevel behind'
         elif self.os_status in (
             OsStatus.EMPTY_OS_ID,
             OsStatus.NO_BRANCH_INFO,

--- a/osid_extension/__main__.py
+++ b/osid_extension/__main__.py
@@ -84,15 +84,7 @@ def determine_os_status(
     if not update_available:
         return odg.model.OsStatus.UP_TO_DATE, greatest_version, eol_date
 
-    more_than_one_patchlevel_behind = osidutil.update_available(
-        osid=osid,
-        os_infos=release_infos,
-        ignore_if_patchlevel_is_next_to_greatest=True,
-    )
-    if more_than_one_patchlevel_behind:
-        return odg.model.OsStatus.MORE_THAN_ONE_PATCHLEVEL_BEHIND, greatest_version, eol_date
-    # otherwise, it's exaclty one patch behind
-    return odg.model.OsStatus.AT_MOST_ONE_PATCHLEVEL_BEHIND, greatest_version, eol_date
+    return odg.model.OsStatus.PATCHLEVEL_BEHIND, greatest_version, eol_date
 
 
 def determine_osid(


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to recent updates to the processing times of outdated OS, a differentiation between the `more-than-one-patchlevel-behind` and `one-patchlevel-behind` categories became obsolete. Here, we made the necessary adaptations to merge these two groups.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
