### PR TITLE
Add odg-operator (and dependencies) to extensions oci-image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -454,6 +454,10 @@ jobs:
                 attribute: ghas.image.repository
               - ref: ocm-resource:extensions.tag
                 attribute: ghas.image.tag
+              - ref: ocm-resource:extensions.repository
+                attribute: odg-operator.image.repository
+              - ref: ocm-resource:extensions.tag
+                attribute: odg-operator.image.tag
           - name: bootstrapping
             dir: charts/bootstrapping
             mappings: []

--- a/Dockerfile.extensions
+++ b/Dockerfile.extensions
@@ -5,6 +5,7 @@ RUN --mount=type=bind,source=/dist,target=/dist \
     bash \
     gcc \
     git \
+    helm \
     libc-dev \
     libffi-dev \
     postgresql16-client \

--- a/requirements.extensions.txt
+++ b/requirements.extensions.txt
@@ -1,2 +1,3 @@
 bdba==0.4.0
 cyclonedx-python-lib
+jsonpath-ng

--- a/setup.extensions.py
+++ b/setup.extensions.py
@@ -36,6 +36,7 @@ def packages():
         'crypto_extension',
         'issue_replicator',
         'malware',
+        'odg_operator',
         'osid_extension',
         'responsibles_extension',
     ]


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
odg-operator (and dependencies) is now part of extensions oci-image
```
