### PR TITLE
Add required odg-extensions from regular extension-cfg

### DIFF
--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -37,6 +37,7 @@ class Services(enum.StrEnum):
     OSID = 'osid'
     RESPONSIBLES = 'responsibles'
     SAST = 'sast'
+    ODG_OPERATOR = 'odg-operator'
 
 
 class VersionAliases(enum.StrEnum):
@@ -628,6 +629,12 @@ class GHASConfig(ExtensionCfgMixins):
         return True
 
 
+@dataclasses.dataclass(kw_only=True)
+class OdgOperatorConfig(ExtensionCfgMixins):
+    service: Services = Services.ODG_OPERATOR
+    required_extension_names: list[str]
+
+
 @dataclasses.dataclass
 class IssueReplicatorMapping(Mapping):
     '''
@@ -852,6 +859,7 @@ class ExtensionsConfiguration:
     delivery_db_backup: DeliveryDBBackup | None
     ghas: GHASConfig | None
     issue_replicator: IssueReplicatorConfig | None
+    odg_operator: OdgOperatorConfig | None
     osid: OsId | None
     responsibles: ResponsiblesConfig | None
     sast: SASTConfig | None

--- a/odg/extensions_cfg.yaml
+++ b/odg/extensions_cfg.yaml
@@ -74,3 +74,7 @@ responsibles:
 
 sast:
   enabled: False
+
+odg_operator:
+  enabled: False
+  required_extension_names: []


### PR DESCRIPTION
odg-operator is designed as regular odg extension. Thus, it has access to common extension cfg.

To offer a great out-of-box experience, an enduser should not be required to bother with odg internals. Thus, the odg-extensions which are part of the required bare minimum for an odg to be an odg, should be configured somewhere "else".
This "else" is the extension cfg, which is used to derive the final set of to-be deployed odg extensions.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
