### PR TITLE
feat(odg): Mount extension-cfg to odg-operator

### DIFF
--- a/charts/extensions/charts/odg-operator/templates/deployment.yaml
+++ b/charts/extensions/charts/odg-operator/templates/deployment.yaml
@@ -52,6 +52,8 @@ spec:
             value: /ocm_repo_mappings/ocm_repo_mappings
           - name: SECRET_FACTORY_PATH
             value: /secrets
+          - name: EXTENSIONS_CFG_PATH
+            value: /extensions_cfg/extensions_cfg
           {{- if default dict .Values.envVars }}
           {{- range $key, $value := .Values.envVars }}
           - name: {{ $key }}
@@ -63,6 +65,8 @@ spec:
               mountPath: /ocm_repo_mappings
             - name: oci-registry
               mountPath: /secrets/oci-registry
+            - name: extensions-cfg
+              mountPath: /extensions_cfg
           {{- if .Values.extensionDefinitions }}
             - name: extension-definitions
               mountPath: /extension-definitions/
@@ -81,6 +85,9 @@ spec:
         - name: oci-registry
           secret:
             secretName: secret-factory-oci-registry
+        - name: extensions-cfg
+          configMap:
+            name: extensions-cfg
       {{- if .Values.extensionDefinitions }}
         - name: extension-definitions
           configMap:


### PR DESCRIPTION
**What this PR does / why we need it**:
Necessary to consume extension-cfg in odg-operator.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Extension-cfg is now mounted to odg-operator.
```
