### PR TITLE
feat(modg): Add more options to pass extension-definitions

### DIFF
--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -629,10 +629,18 @@ class GHASConfig(ExtensionCfgMixins):
         return True
 
 
+@dataclasses.dataclass
+class ExtensionDefinitionOcmReference:
+    component_name: str
+    component_version: str
+    artefact_name: str
+
+
 @dataclasses.dataclass(kw_only=True)
 class OdgOperatorConfig(ExtensionCfgMixins):
     service: Services = Services.ODG_OPERATOR
     required_extension_names: list[str]
+    extension_ocm_references: list[ExtensionDefinitionOcmReference] = dataclasses.field(default_factory=list) # noqa: E501
 
 
 @dataclasses.dataclass

--- a/odg/extensions_cfg.yaml
+++ b/odg/extensions_cfg.yaml
@@ -78,3 +78,4 @@ sast:
 odg_operator:
   enabled: False
   required_extension_names: []
+  extension_ocm_references: []

--- a/odg_operator/__main__.py
+++ b/odg_operator/__main__.py
@@ -845,10 +845,16 @@ if __name__ == '__main__':
     recursion_depth = -1 if parsed.recursive else 0
     resource_nodes = []
 
-    for extension in parsed.extensions:
-        extension: str
+    for extension_ref in [
+        odg.extensions_cfg.ExtensionDefinitionOcmReference(
+            component_name=extension[0],
+            component_version=extension[1],
+            artefact_name=extension[2],
+        )
+        for extension in [e.split(':') for e in parsed.extensions]
+    ] + odg_operator_cfg.extension_ocm_references:
 
-        component_id, artefact_name = extension.rsplit(':', 1)
+        component_id = f'{extension_ref.component_name}:{extension_ref.component_version}'
         component = component_descriptor_lookup(component_id).component
         for resource_node in cnudie.iter.iter(
             component=component,
@@ -858,7 +864,7 @@ if __name__ == '__main__':
         ):
             if (
                 resource_node.resource.type == ODG_EXTENSION_ARTEFACT_TYPE
-                and resource_node.resource.name == artefact_name
+                and resource_node.resource.name == extension_ref.artefact_name
             ):
                 resource_nodes.append(resource_node)
 


### PR DESCRIPTION
Additionally reading odg-extension-definition references from the extension-cfg is useful, as we enable a more convienent way to configure the operator.
This is especially useful considering we deploy via a helm-values pre-processing step (generate_helm_values.py).

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
odg-extension-definitions can now also be passed via extension-cfg.
```
