### PR TITLE
feat(modg): Add missing ODG extension-definitions

### DIFF
--- a/extension-definitions.yaml
+++ b/extension-definitions.yaml
@@ -401,3 +401,55 @@ outputs: []
 dependencies:
   - delivery-service
   - delivery-db
+---
+name: delivery-db-backup
+installation:
+  ocm_references:
+    - helm_chart_name: extensions
+      name: ocm.software/ocm-gear/delivery-service
+      version: "0.1198.0-dev"
+      artefact:
+        name: extensions
+        version: "0.1198.0-dev"
+      mappings:
+        - name: extensions
+          version: "0.1198.0-dev"
+          artefact_type: helmchart-imagemap
+  value_templates:
+    - helm_chart_name: extensions
+      helm_attribute: delivery-db-backup.target_namespace
+      value: ${target_namespace}
+      value_type: python-string-template
+    - helm_chart_name: extensions
+      helm_attribute: delivery-db-backup.enabled
+      value: True
+      value_type: literal
+outputs: []
+dependencies:
+  - delivery-db
+---
+name: ghas
+installation:
+  ocm_references:
+    - helm_chart_name: extensions
+      name: ocm.software/ocm-gear/delivery-service
+      version: "0.1198.0-dev"
+      artefact:
+        name: extensions
+        version: "0.1198.0-dev"
+      mappings:
+        - name: extensions
+          version: "0.1198.0-dev"
+          artefact_type: helmchart-imagemap
+  value_templates:
+    - helm_chart_name: extensions
+      helm_attribute: ghas.target_namespace
+      value: ${target_namespace}
+      value_type: python-string-template
+    - helm_chart_name: extensions
+      helm_attribute: ghas.enabled
+      value: True
+      value_type: literal
+outputs: []
+dependencies:
+  - delivery-service


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
\cc @8R0WNI3 
both extensions are implemented as k8s cronjob.
This requires certain configuration to be rendered into the manifest.
Therefore, this cannot be installed by odg users via runtime configuration.

Do **not** expose these config options via odg-operator interface for now, but rely on sane defaults specified in helm charts.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
delivery-db odg-extension is now also available via managed open-delivery-gear
```
