### PR TITLE
feat(modg): Deploy delivery-db password as secret

### DIFF
--- a/charts/bootstrapping/templates/secrets.yaml
+++ b/charts/bootstrapping/templates/secrets.yaml
@@ -28,6 +28,17 @@ metadata:
 type: Opaque
 stringData: {{ include "secret" (index $secrets "delivery-db") }}
 ---
+{{- range $name, $db := (index $secrets "delivery-db") }} # there will only be one item
+apiVersion: v1
+kind: Secret
+metadata:
+  name: delivery-db-password
+  namespace: {{ $.Values.target_namespace | default $.Release.Namespace }}
+type: Opaque
+stringData:
+  postgres-password: {{ $db.password }}
+---
+{{- end }}
 {{- end }}
 {{- if $secrets.github }}
 apiVersion: v1


### PR DESCRIPTION
postgres requires a password which must either be templated into the deployment itself, or be referenced via a secret.
first variant is no option, because the manifest is templated centrally (odg-operator) and has no user secrets at hand. thus, deploy a secret in user cluster (as part of bootstrap chart) which the postgres deployment can use to extract the password.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
