### PR TITLE
Add default value for extension definition value templates

### DIFF
--- a/extension-definitions.yaml
+++ b/extension-definitions.yaml
@@ -58,6 +58,16 @@ installation:
       helm_attribute: ingress.annotations."nginx.ingress.kubernetes.io/proxy-next-upstream-tries"
       value: '"0"'
       value_type: literal
+    - helm_chart_name: delivery-service
+      helm_attribute: autoscaler.minReplicas
+      value: '${deliveryServiceMinReplicas}'
+      value_type: python-string-template
+      default: '2'
+    - helm_chart_name: delivery-service
+      helm_attribute: autoscaler.maxReplicas
+      value: '${deliveryServiceMaxReplicas}'
+      value_type: python-string-template
+      default: '10'
 outputs:
   - name: delivery-service-url
     value: https://delivery-service.${base_url}

--- a/odg_operator/__main__.py
+++ b/odg_operator/__main__.py
@@ -239,6 +239,7 @@ def create_or_update_odg(
                         jsonpaths=outputs_jsonpath,
                         substitution_context=odg.context,
                         value_type=value_template.value_type,
+                        default_value=value_template.default,
                     )
                 )
                 for value_template in extension_definition.installation.value_templates

--- a/odg_operator/odg_model.py
+++ b/odg_operator/odg_model.py
@@ -96,6 +96,7 @@ class ExtensionInstanceValue:
 @dataclasses.dataclass
 class ValueTemplate(ExtensionInstanceValue):
     value_type: ValueType
+    default: str | bool | list | dict | None = None
 
 
 @dataclasses.dataclass

--- a/odg_operator/odg_util.py
+++ b/odg_operator/odg_util.py
@@ -104,6 +104,7 @@ def template_and_resolve_jsonpath(
     value_type: odgm.ValueType,
     substitution_context: dict,
     jsonpaths: dict,
+    default_value: str | bool | list | dict | None=None,
 ) -> str | bool | list | dict:
     '''
     Processes provided value according to its type.
@@ -118,10 +119,16 @@ def template_and_resolve_jsonpath(
         `value_type`: defining how to process the value
         `substitution_context`: dictionary for placeholder substitution.
         `jsonpaths`: dictionary to replace using JSONPath semantics after substitution.
+        `default_value`: The value used instead of `value` if the substitution context is missing
     '''
 
     if isinstance(value, str):
-        templated = string.Template(value).substitute(substitution_context)
+        try:
+            templated = string.Template(value).substitute(substitution_context)
+        except KeyError:
+            if default_value is None:
+                raise
+            templated = default_value
 
         if value_type is odgm.ValueType.LITERAL:
             return value
@@ -153,12 +160,14 @@ def template_and_resolve_jsonpath(
                     substitution_context=substitution_context,
                     jsonpaths=jsonpaths,
                     value_type=value_type,
+                    default_value=default_value,
                 ),
                 template_and_resolve_jsonpath(
                     value=value,
                     substitution_context=substitution_context,
                     jsonpaths=jsonpaths,
                     value_type=value_type,
+                    default_value=default_value,
                 )
             )
             for key, value in value.items()
@@ -171,6 +180,7 @@ def template_and_resolve_jsonpath(
                 substitution_context=substitution_context,
                 jsonpaths=jsonpaths,
                 value_type=value_type,
+                default_value=default_value,
             )
             for entry in value
         ]

--- a/test/test_modg_extension.py
+++ b/test/test_modg_extension.py
@@ -86,3 +86,22 @@ def test_extensions(extension_definitions):
     ) == {
         'foo': 'bar.my-domain.com',
     }
+
+    with pytest.raises(KeyError):
+        odgu.template_and_resolve_jsonpath(
+            value={'foo': 'bar.${base_url}'},
+            jsonpaths=outputs,
+            substitution_context={},
+            value_type=odgm.ValueType.PYTHON_STRING_TEMPLATE,
+            default_value=None,
+        )
+
+    assert odgu.template_and_resolve_jsonpath(
+        value={'foo': 'bar.${base_url}'},
+        jsonpaths=outputs,
+        substitution_context={},
+        value_type=odgm.ValueType.PYTHON_STRING_TEMPLATE,
+        default_value='bar.default-domain.com',
+    ) == {
+        'foo': 'bar.default-domain.com',
+    }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Extension definition helm value templates now support specification of a default value
```
```improvement operator
The delivery-service min/max replicas can now be specified via `.context.deliveryService{Min|Max}Replicas`
```
