### PR TITLE
Allow configuration of `reuse_discovery_date` in finding-cfg

### DIFF
--- a/odg/findings.py
+++ b/odg/findings.py
@@ -482,23 +482,48 @@ class SharedCfgReference:
 
 
 @dataclasses.dataclass
+class ReuseDiscoveryDate:
+    '''
+    :param bool enabled:
+        Specifies whether discovery dates should be reused at all.
+    :param str max_reuse_time:
+        The time after the last update of a finding during which a discovery date is reused.
+        Known units:
+            - seconds: s, sec
+            - minutes: m, min
+            - hours: h, hr
+            - days: d (default)
+            - weeks: w
+            - years: a
+    '''
+    enabled: bool = True
+    max_reuse_time: str | int | None = None
+
+    def __post_init__(self):
+        if self.max_reuse_time is not None:
+            self.max_reuse_time = util.convert_to_timedelta(self.max_reuse_time)
+
+
+@dataclasses.dataclass
 class Finding:
     '''
-    :param Datatype type
+    :param Datatype type:
     :param list[FindingCategorisation] categorisation:
         The available categories for this type of findings and information on how to assign the
         findings to one of these categories. If a string is given, the corresponding standard
         categorisations are automatically set after instantiation of this class.
     :param list[FindingFilter] filter:
         An optional filter to restrict detection of findings to certain artefacts.
-    :param RuleSet ruleset:
+    :param RuleSet rescoring_ruleset:
         Based on the finding type, there might be a ruleset available to automatically suggest/do
         rescorings. If a string is given, the corresponding standard ruleset is automatically set
         after instantiation of this class.
     :param FindingIssues issues:
         Configuration whether and if yes, how, GitHub tracking issues should be created/updated.
-    :param RescoringScope default_scope
+    :param RescoringScope default_scope:
         Default scope selection to be used for rescoring via the Delivery-Dashboard.
+    :param ReuseDiscoveryDate reuse_discovery_date:
+        Specifies the behaviour of reusing discovery dates of existing findings.
     '''
     type: odg.model.Datatype
     categorisations: SharedCfgReference | list[FindingCategorisation]
@@ -508,6 +533,7 @@ class Finding:
     default_scope: RescoringSpecificity = dataclasses.field(
         default_factory=lambda: RescoringSpecificity.ARTEFACT
     )
+    reuse_discovery_date: ReuseDiscoveryDate = dataclasses.field(default_factory=ReuseDiscoveryDate)
 
     @staticmethod
     def from_dict(


### PR DESCRIPTION
To control the behaviour if and when existing discovery dates of existing findings should be reused, i.e. after which period of the last update of a finding the discovery date should be re-created.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Allow configuration of `reuse_discovery_date` in finding-cfg
```
