### PR TITLE
Split manifests for managed resource into chunks to fit k8s size limit

### DIFF
--- a/odg_operator/__main__.py
+++ b/odg_operator/__main__.py
@@ -620,15 +620,6 @@ def reconcile(
                     namespace=odg.namespace,
                     label_selector=f'{ODG_NAME_LABEL}={odg.name}',
                 ).get('items', []):
-
-                    kubernetes_api.custom_kubernetes_api.delete_namespaced_custom_object(
-                        group=odgm.ManagedResourceMeta.group,
-                        version=odgm.ManagedResourceMeta.version,
-                        plural=odgm.ManagedResourceMeta.plural,
-                        namespace=odg.namespace,
-                        name=managed_resource['metadata']['name'],
-                    )
-
                     delete_managed_resource(
                         kubernetes_api=kubernetes_api,
                         managed_resource=managed_resource,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Manifests for managed resources are now split into chunks to fit Kubernetes' size limit for secrets
```
