### PR TITLE
Allow `ComponentArtefactId` to contain empty strings instead of `None`

### DIFF
--- a/ocm_util.py
+++ b/ocm_util.py
@@ -91,11 +91,20 @@ async def find_artefact_node_async(
         raise RuntimeError('this line should never be reached')
 
     for a in artefacts:
-        if a.name != artefact.artefact.artefact_name:
+        if (
+            (a.name or artefact.artefact.artefact_name)
+            and a.name != artefact.artefact.artefact_name
+        ):
             continue
-        if a.version != artefact.artefact.artefact_version:
+        if (
+            (a.version or artefact.artefact.artefact_version)
+            and a.version != artefact.artefact.artefact_version
+        ):
             continue
-        if a.type != artefact.artefact.artefact_type:
+        if (
+            (a.type or artefact.artefact.artefact_type)
+            and a.type != artefact.artefact.artefact_type
+        ):
             continue
         if (
             odg.model.normalise_artefact_extra_id(a.extraIdentity)

--- a/rescore/artefacts.py
+++ b/rescore/artefacts.py
@@ -79,6 +79,7 @@ async def _find_artefact_metadata(
             dm.ArtefactMetaData.component_name == artefact.component_name,
             sa.or_(
                 dm.ArtefactMetaData.component_version == sa.null(),
+                dm.ArtefactMetaData.component_version == '',
                 dm.ArtefactMetaData.component_version == artefact.component_version,
             ),
             dm.ArtefactMetaData.artefact_kind == artefact.artefact_kind,
@@ -115,18 +116,22 @@ async def _find_rescorings(
             sa.or_(
                 # regular `not` or `is None` not working with sqlalchemy
                 dm.ArtefactMetaData.component_name == sa.null(),
+                dm.ArtefactMetaData.component_name == '',
                 dm.ArtefactMetaData.component_name == artefact.component_name,
             ),
             sa.or_(
                 dm.ArtefactMetaData.component_version == sa.null(),
+                dm.ArtefactMetaData.component_version == '',
                 dm.ArtefactMetaData.component_version == artefact.component_version
             ),
             sa.or_(
                 dm.ArtefactMetaData.artefact_name == sa.null(),
+                dm.ArtefactMetaData.artefact_name == '',
                 dm.ArtefactMetaData.artefact_name == artefact.artefact.artefact_name,
             ),
             sa.or_(
                 dm.ArtefactMetaData.artefact_version == sa.null(),
+                dm.ArtefactMetaData.artefact_version == '',
                 dm.ArtefactMetaData.artefact_version == artefact.artefact.artefact_version,
             ),
             sa.or_(
@@ -681,6 +686,9 @@ class Rescore(aiohttp.web.View):
         artefact_type = util.param(params, 'artefactType', required=True)
         artefact_extra_id = json.loads(util.param(params, 'artefactExtraId', default='{}'))
         type_filter = params.getall('type', default=[])
+
+        if component_version == 'greatest':
+            component_version = None
 
         finding_cfgs = self.request.app[consts.APP_FINDING_CFGS]
         for finding_type in type_filter:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The rescoring route is now capable of handling artefacts with empty string values instead of empty values
```
