### PR TITLE
enh(modg): Flag CRDs to be excluded from resource-manager deletion

### DIFF
--- a/charts/delivery-service/crds/runtime-artefact.yaml
+++ b/charts/delivery-service/crds/runtime-artefact.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: runtimeartefacts.delivery-gear.gardener.cloud
+  annotations:
+    resources.gardener.cloud/keep-object: "true"
 spec:
   group: delivery-gear.gardener.cloud
   scope: Namespaced

--- a/charts/extensions/crds/backlog-item.yaml
+++ b/charts/extensions/crds/backlog-item.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: backlogitems.delivery-gear.gardener.cloud
+  annotations:
+    resources.gardener.cloud/keep-object: "true"
 spec:
   group: delivery-gear.gardener.cloud
   scope: Namespaced

--- a/charts/extensions/crds/log-collection.yaml
+++ b/charts/extensions/crds/log-collection.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: logcollections.delivery-gear.gardener.cloud
+  annotations:
+    resources.gardener.cloud/keep-object: "true"
 spec:
   group: delivery-gear.gardener.cloud
   scope: Namespaced


### PR DESCRIPTION
Necessary for scenario where multiple ODGs are running within the very same shootcluster.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
CRDs are no longer deleted from ODG workload cluster by gardener-resource-manager.
```
