### PR TITLE
enh(odg): Do not retry high-frequent cronjobs on job level

### DIFF
--- a/charts/extensions/charts/access-manager/templates/access-manager.yaml
+++ b/charts/extensions/charts/access-manager/templates/access-manager.yaml
@@ -12,6 +12,7 @@ spec:
   failedJobsHistoryLimit: {{ default 1 .Values.failed_jobs_history_limit }}
   jobTemplate:
     spec:
+      backoffLimit: 0
       ttlSecondsAfterFinished: {{ default 43200 .Values.ttl_seconds_after_finished }} # 43200 -> 12h
       template:
         metadata:

--- a/charts/extensions/charts/artefact-enumerator/templates/artefact-enumerator.yaml
+++ b/charts/extensions/charts/artefact-enumerator/templates/artefact-enumerator.yaml
@@ -12,6 +12,7 @@ spec:
   failedJobsHistoryLimit: {{ default 1 .Values.failed_jobs_history_limit }}
   jobTemplate:
     spec:
+      backoffLimit: 0
       ttlSecondsAfterFinished: {{ default 43200 .Values.ttl_seconds_after_finished }} # 43200 -> 12h
       template:
         metadata:

--- a/charts/extensions/charts/cache-manager/templates/cache-manager.yaml
+++ b/charts/extensions/charts/cache-manager/templates/cache-manager.yaml
@@ -12,6 +12,7 @@ spec:
   failedJobsHistoryLimit: {{ default 1 .Values.failed_jobs_history_limit }}
   jobTemplate:
     spec:
+      backoffLimit: 0
       ttlSecondsAfterFinished: {{ default 43200 .Values.ttl_seconds_after_finished }} # 43200 -> 12h
       template:
         metadata:


### PR DESCRIPTION
Job failures are typically due to misconfiguration rather than transient issues, so immediate retries rarely succeed but block node resources. The high-frequency cronjobs provides sufficient retry coverage.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
High-frequent cronjobs no longer retry failed jobs
```
