### PR TITLE
Only scan resources of type `ociImage` for OsIds if not filter is set

### DIFF
--- a/osid_extension/__main__.py
+++ b/osid_extension/__main__.py
@@ -242,6 +242,20 @@ def process_artefact(
             )
         return
 
+    # only check if the resource type is supported if no specific filter is set
+    # -> default to only scan resources of type `ociImage`
+    if not osid_finding_config.filter and not extension_cfg.is_supported(
+        access_type=access.type,
+        artefact_type=resource_node.resource.type,
+    ):
+        if extension_cfg.on_unsupported is odg.extensions_cfg.WarningVerbosities.FAIL:
+            raise TypeError(
+                f'{access.type} with {resource_node.resource.type=} is not supported by the OSID '
+                'extension, maybe the filter configurations have to be adjusted to filter out these '
+                'types'
+            )
+        return
+
     osid: odg.model.OperatingSystemId | None = base_image_osid(
         oci_client=oci_client,
         resource=resource_node.resource,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
In case no explicit artefact filter is configured for findings of type `osid`, only resources of type `ociImage` will be scanned
```
