### PR TITLE
Mv function from cc-utils

### DIFF
--- a/cli/_bdba.py
+++ b/cli/_bdba.py
@@ -7,7 +7,6 @@ import pprint
 import tabulate
 
 import cnudie.access
-import oci
 import ocm
 import ocm.iter
 import tarutil
@@ -155,7 +154,7 @@ def scan(
             access = resource_node.resource.access
 
             if access.type is ocm.AccessType.OCI_REGISTRY:
-                content_iterator = oci.image_layers_as_tarfile_generator(
+                content_iterator = ocm_util.image_layers_as_tarfile_generator(
                     image_reference=access.imageReference,
                     oci_client=oci_client,
                     include_config_blob=False,


### PR DESCRIPTION
ODG is the only known user of this function.
Mv to avoid increasing the footprint of gardener-oci-package.

see:
https://github.com/gardener/cc-utils/pull/1457

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
NONE
```
