### PR TITLE
Exit with error in BDBA scan if uploaded/scanned file seems to be empty

### DIFF
--- a/bdba/model.py
+++ b/bdba/model.py
@@ -246,6 +246,8 @@ class AnalysisResult(Result):
     fail_reason: str | None
     components: list[Component] = dataclasses.field(default_factory=list)
     custom_data: dict[str, str] = dataclasses.field(default_factory=dict)
+    binary_bytes: int | None
+    scanned_bytes: int | None
 
 
 @dataclasses.dataclass

--- a/bdba_utils/scan.py
+++ b/bdba_utils/scan.py
@@ -211,6 +211,13 @@ class ResourceGroupProcessor:
             logger.error(f'scan of {scanned_element=} failed; {scan_result=}')
             return
 
+        if not (scan_result.binary_bytes and scan_result.scanned_bytes):
+            logger.error(
+                f'scan of {scanned_element=} failed: uploaded or scanned file is empty '
+                f'({scan_result.binary_bytes=}, {scan_result.scanned_bytes=})'
+            )
+            return
+
         logger.info(
             f'scan of {scan_result.display_name} succeeded, going to post-process results'
         )


### PR DESCRIPTION
**What this PR does / why we need it**:
In the past, errors in conjunction with the BDBA scan were identifiable in case the uploaded or scanned file seems to be empty (0 bytes identified). To prevent follow-up issues in that case, early-exit with an error instead if 0 bytes were identified.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
In case a BDBA scan identifies a file size of 0 bytes, an error is raised and the scan is aborted to prevent follow-up issues.
```
