### PR TITLE
fix(blackduck): add default factory for label_rules

### DIFF
--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -297,7 +297,7 @@ class BlackDuckConfig(BacklogItemMixins):
     service: Services = Services.BLACKDUCK
     delivery_service_url: str
     mappings: list[BlackDuckExtensionMapping]
-    label_rules: list[BlackDuckLabelRule]
+    label_rules: list[BlackDuckLabelRule] = dataclasses.field(default_factory=list)
     interval: int = 60 * 60 * 24 # 24h
     on_unsupported: WarningVerbosities = WarningVerbosities.WARNING
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
Added default value (empty list) for BlackDuck's extension config's `label_rules` property
```
