### PR TITLE
Make `path` and `line` properties of ghas finding optional

### DIFF
--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -681,8 +681,8 @@ def ghas_summary(
     finding_table_callback = {
         'Secret Type': lambda f, _: f'`{f.finding.data.secret_type}`',
         'Secret': lambda f, _: f'`{f.finding.data.secret}`',
-        'Path': lambda f, _: f'`{f.finding.data.path}`',
-        'Line': lambda f, _: f'`{f.finding.data.line}`',
+        'Path': lambda f, _: f'`{f.finding.data.path}`' if f.finding.data.path else '',
+        'Line': lambda f, _: f'`{f.finding.data.line}`' if f.finding.data.line else '',
         'Display Name': lambda f, _: f'`{f.finding.data.secret_type_display_name}`',
         'Ref': lambda f, _: f'[ref]({f.finding.data.html_url})',
         'Severity': lambda f, g: _severity_str(

--- a/odg/model.py
+++ b/odg/model.py
@@ -631,8 +631,8 @@ class GitHubSecretFinding(Finding):
     secret_type: str
     secret_type_display_name: str
     resolution: str | None
-    path: str
-    line: int
+    path: str | None
+    line: int | None
     location_type: str
     url: str
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases (e.g. if secret was detected within a pull request), the GitHub Secret finding won't contain a `path` and `line` property.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix developer
The GitHub Secret finding model now allows the `path` and `line` properties to be empty (e.g. in case secret was detected within a pull request)
```
