### PR TITLE
Use "standard" `ocm_repository_lookup` as dummy lookup

### DIFF
--- a/delivery_db_backup.py
+++ b/delivery_db_backup.py
@@ -223,7 +223,7 @@ def delete_old_backup_versions(
     )
 
     lookup = cnudie.retrieve.oci_component_descriptor_lookup(
-        ocm_repository_lookup=lookups.init_ocm_repository_lookup(ocm_repo),
+        ocm_repository_lookup=cnudie.retrieve.ocm_repository_lookup(ocm_repo),
         oci_client=oci_client,
     )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent irritating log message from `lookups.init_ocm_repository_lookup` because an actual "lookup" is not required here because the one and only `ocm_repo` is specified explicitly anyways.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
