### PR TITLE
Use `<br>` instead of `\n` in markdown for linebreaks within a table

### DIFF
--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -176,7 +176,7 @@ def _rescoring_comment(
     if not (comment := aggregated_finding.rescorings[0].data.comment):
         return ''
 
-    return comment
+    return comment.replace('\n', '<br>')
 
 
 def _issue_ref(


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix user
Newlines within a table cell in the GitHub compliance issues are now displayed correctly
```
