### PR TITLE
fix: Mount `github` secrets to `cache-manager` deployment

### DIFF
--- a/charts/extensions/charts/cache-manager/templates/cache-manager.yaml
+++ b/charts/extensions/charts/cache-manager/templates/cache-manager.yaml
@@ -43,6 +43,10 @@ spec:
             volumeMounts:
             - name: delivery-db
               mountPath: /secrets/delivery-db
+            - name: github
+              mountPath: /secrets/github
+            - name: github-app
+              mountPath: /secrets/github-app
             - name: kubernetes
               mountPath: /secrets/kubernetes
             - name: oci-registry
@@ -58,6 +62,14 @@ spec:
             - name: delivery-db
               secret:
                 secretName: secret-factory-delivery-db
+            - name: github
+              secret:
+                secretName: secret-factory-github
+                optional: true
+            - name: github-app
+              secret:
+                secretName: secret-factory-github-app
+                optional: true
             - name: kubernetes
               secret:
                 secretName: secret-factory-kubernetes


### PR DESCRIPTION
GitHub credentials might be required in case the `SharedCfgReference` of the findings-cfg references contents of a GitHub repository.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
The `github` secrets are now mounted to the `cache-manager` pod to allow resolving of `SharedCfgReference`
```
