### PR TITLE
fix: Pass `reference_component` to upgrade-PRs if available

### DIFF
--- a/components.py
+++ b/components.py
@@ -831,6 +831,8 @@ class UpgradePRs(aiohttp.web.View):
             )
 
             repo_url = source.access.repoUrl if source else component_name
+        else:
+            component = None
 
         def upgrade_pr_to_dict(
             upgrade_pr: github.pullrequest.UpgradePullRequest,
@@ -876,6 +878,7 @@ class UpgradePRs(aiohttp.web.View):
             upgrade_prs = github.pullrequest.iter_upgrade_pullrequests(
                 repository=repo,
                 state=state,
+                reference_component=component,
             )
 
             return [


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to an upstream refactoring, depending on the kind of the upgrade-PR, the implementation may require a `reference_component` to be provided in order to resolve the OCM component of the upgrade-PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix user
Fixed a bug where upgrade-PRs of kind `name` (instead of `component`) could not be retrieved due to a missing reference component
```
