### PR TITLE
Normalize BDBA BDIO display names for Black Duck compatibility

### DIFF
--- a/bdba_utils/scan.py
+++ b/bdba_utils/scan.py
@@ -28,6 +28,15 @@ logger = logging.getLogger(__name__)
 ci.log.configure_default_logging(print_thread_id=True)
 
 
+def normalize_display_name(value: str) -> str:
+    return (
+        value
+        .replace('/', '_')
+        .replace('+', '_')
+        .replace(' ', '_')
+    )
+
+
 class ResourceGroupProcessor:
     def __init__(
         self,
@@ -45,11 +54,15 @@ class ResourceGroupProcessor:
     ) -> bdba_utils.model.ScanRequest:
         component = resource_node.component
         resource = resource_node.resource
-        display_name = f'{resource.name}_{resource.version}_{component.name}_{resource.type}'.replace('/', '_') # noqa: E501
+        display_name = normalize_display_name(
+            value=f'{resource.name}_{resource.version}_{component.name}_{resource.type}'
+        )
 
         if resource.extraIdentity:
             # peers are not required here as version is considered anyways
-            display_name += f'_{resource.identity(peers=())}'.replace('/', '_')
+            display_name += '_' + normalize_display_name(
+                value=f'{resource.identity(peers=())}'
+            )
 
         component_artefact_metadata = bdba_utils.util.component_artefact_metadata(
             resource_node=resource_node,


### PR DESCRIPTION
The BDIO display name generated during BDBA export is reused across multiple BDIO fields (including project-related values and file paths). Special characters such as + and spaces caused inconsistent project resolution and follow-up lookup behavior in Black Duck/Iungo.

By normalizing the display name at the source, all derived BDIO values stay consistent and we avoid patching the BDIO payload later in the Black Duck worker.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator
Normalize BDBA BDIO display names for Black Duck compatibility
```
