### PR TITLE
Use order of OCM repos as priority (again)

### DIFF
--- a/lookups.py
+++ b/lookups.py
@@ -336,15 +336,18 @@ def init_ocm_repository_lookup(
         /,
     ) -> collections.abc.Iterable[str]:
         component_name = cnudie.util.to_component_name(component)
-        repositories = set()
+        seen_repositories = set()
 
         for ocm_repository_cfg in resolved_ocm_repository_cfgs:
             if not ocm_repository_cfg.prefix_matches(component_name):
                 continue
 
-            repositories.add(ocm_repository_cfg.repository)
+            if (repository := ocm_repository_cfg.repository) in seen_repositories:
+                continue
 
-        yield from repositories
+            seen_repositories.add(repository)
+
+            yield repository
 
     return ocm_repository_lookup
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since a `set` is an unordered collections, yielding from it will drop the intial order and thus the possibility to use the order as priority.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix operator
The configuration order of the OCM repositories is now used as priority (again) -> first matching entry wins
```
