### PR TITLE
add optional blackduck distribution_mode to target

### DIFF
--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -285,6 +285,7 @@ class BlackDuckLabelRule:
 class BlackDuckTarget:
     group_id: str
     host: str
+    distribution_mode_overwrite: str | None = None
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
add optional `distribution_mode_overwrite` to Black Duck target config to allow per-target control of project version distribution updates (e.g., set to SAAS)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator
Add optional `distribution_mode_overwrite` to Black Duck target config to allow per-target control of project version distribution updates
```
