### PR TITLE
fix: add delivery service url to sbom config in extensions_cfg

### DIFF
--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -1147,6 +1147,7 @@ class SBOMGeneratorMapping(Mapping):
 @dataclasses.dataclass(kw_only=True)
 class SBOMGeneratorConfig(BacklogItemMixins):
     service: Services = Services.SBOM_GENERATOR
+    delivery_service_url: str
     mappings: list[SBOMGeneratorMapping]
     on_unsupported: WarningVerbosities = WarningVerbosities.WARNING
     create_new_scan_if_missing: bool = False


### PR DESCRIPTION
**What this PR does / why we need it**: 

sbom-generator extension pod is crashed. When delivery_service_url isn't configured, delivery_client becomes None and it crashes the app. It happened when sbom-generator extension called  delivery_client.update_metadata.

This PR added delivery service url to extension config for SBOM.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
add delivery service url to sbom config in extensions_cfg
```
