### PR TITLE
Add `brotli` compression to secrets for Gardener Resource Manager

### DIFF
--- a/odg_operator/__main__.py
+++ b/odg_operator/__main__.py
@@ -13,6 +13,7 @@ import tarfile
 import tempfile
 import textwrap
 
+import brotli
 import dacite
 import kubernetes.client
 import kubernetes.client.rest
@@ -197,7 +198,7 @@ def encode_manifest(
     if isinstance(manifest, dict):
         manifest = [manifest]
 
-    return base64.b64encode(yaml.dump_all(manifest).encode()).decode()
+    return base64.b64encode(brotli.compress(yaml.dump_all(manifest).encode())).decode()
 
 
 def encode_and_split_manifests(
@@ -438,7 +439,7 @@ def create_or_update_odg(
                         }
                     ),
                     data={
-                        'data.yaml': encoded_manifests[idx],
+                        'data.yaml.br': encoded_manifests[idx],
                     },
                 )
                 core_api = kubernetes_api.core_kubernetes_api

--- a/requirements.extensions.txt
+++ b/requirements.extensions.txt
@@ -1,3 +1,4 @@
 bdba==0.10.0
+brotli
 cyclonedx-python-lib
 jsonpath-ng


### PR DESCRIPTION
**What this PR does / why we need it**:
When managing CRDs using Gardener's Resource Manager, they must be stored within a Kubernetes secret first. As secrets have a maximum allowed size of 1 MiB, this limit is easily exceeded due to the usual length of a CRD. In case there are multiple manifests, they are already spread across different secrets. However, this cannot be done if a single manifest already exceeds the limit. To also handle those cases, compress the manifest first before they are written to a secret using Brotli. Brotli is chosen for compression because it is supported by the Gardener Resource Manager per default, see:
https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#compression

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator
Manifests are now compressed using Brotli before they are written to a secret for the Gardener Resource Manager
```
