### PR TITLE
fix: Filter Helm values in ODG operator based on Helm chart name

### DIFF
--- a/odg_operator/__main__.py
+++ b/odg_operator/__main__.py
@@ -364,7 +364,7 @@ def create_or_update_odg(
             installation_values_for_artefact = [
                 iv
                 for iv in extension_instance.values
-                if iv.helm_chart_name == artefact.name
+                if iv.helm_chart_name == installation_artefact.helm_chart_name
             ]
 
             merged_installation_values = {}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
The Helm values in the ODG operator are now (consistently) mapped via Helm chart name to the Helm chart instead of Helm chart name and OCM artefact name
```
