### PR TITLE
Support regex patterns in OAuth subject name matching

### DIFF
--- a/access_manager_extension.py
+++ b/access_manager_extension.py
@@ -104,7 +104,7 @@ def iter_github_user_role_bindings(
         ) -> secret_mgmt.oauth_cfg.Subject | None:
             for subject in subjects:
                 if subject.type is secret_mgmt.oauth_cfg.SubjectType.GITHUB_USER:
-                    if subject.name == identifier.username:
+                    if subject.matches(identifier.username):
                         return subject
 
                 elif subject.type is secret_mgmt.oauth_cfg.SubjectType.GITHUB_ORG:
@@ -162,7 +162,7 @@ def iter_github_app_role_bindings(
         ) -> secret_mgmt.oauth_cfg.Subject | None:
             for subject in subjects:
                 if subject.type is secret_mgmt.oauth_cfg.SubjectType.GITHUB_APP:
-                    if subject.name == identifier.app_name:
+                    if subject.matches(identifier.app_name):
                         return subject
 
         for role_binding in oauth_cfg.role_bindings:

--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -1663,12 +1663,16 @@ secrets:
           subjects:
               # @param secrets.oauth-cfg.<name>.role_bindings[].subjects[].type the type of subject
               # options:
-              # - github-app: name is expected as <app-slug>
-              # - github-user: name is expected as <username>
-              # - github-org: name is expected as <org-name>
-              # - github-team: name is expected as <org-name>/<team-slug>
+              # - github-app: name is matched as a regex against the app slug
+              # - github-user: name is matched as a regex against the username
+              # - github-org: name is expected as <org-name> (exact, used to query GitHub API)
+              # - github-team: name is expected as <org-name>/<team-slug> (exact, used to query GitHub API)
             - type: ""
-              # @param secrets.oauth-cfg.<name>.role_bindings[].subjects[].name the name of subject
+              # @param secrets.oauth-cfg.<name>.role_bindings[].subjects[].name the name of the subject.
+              # For github-user and github-app, the value is interpreted as a Python regex (re.fullmatch)
+              # so plain names (e.g. "alice") match literally, while patterns (e.g. "^my-bot-.*") are
+              # also supported. For github-org and github-team, the value is used as-is to query the
+              # GitHub API for membership and is not interpreted as a regex.
               name: ""
 
   # @param secrets.ppms mapping of named PPMS credentials (name is freely selectable)

--- a/middleware/auth.py
+++ b/middleware/auth.py
@@ -337,7 +337,7 @@ def find_role_bindings(
             for subject in subjects:
                 if isinstance(user_identifier, dm.GitHubUserIdentifier):
                     if subject.type is secret_mgmt.oauth_cfg.SubjectType.GITHUB_USER:
-                        if subject.name == user_identifier.username:
+                        if subject.matches(user_identifier.username):
                             return subject
 
                     elif subject.type is secret_mgmt.oauth_cfg.SubjectType.GITHUB_ORG:
@@ -362,7 +362,7 @@ def find_role_bindings(
 
                 elif isinstance(user_identifier, dm.GitHubAppIdentifier):
                     if subject.type is secret_mgmt.oauth_cfg.SubjectType.GITHUB_APP:
-                        if subject.name == user_identifier.app_name:
+                        if subject.matches(user_identifier.app_name):
                             return subject
 
         for role_binding in oauth_cfg.role_bindings:

--- a/secret_mgmt/oauth_cfg.py
+++ b/secret_mgmt/oauth_cfg.py
@@ -1,5 +1,6 @@
 import dataclasses
 import enum
+import re
 
 import util
 
@@ -22,6 +23,9 @@ class SubjectType(enum.StrEnum):
 class Subject:
     type: SubjectType
     name: str
+
+    def matches(self, name: str) -> bool:
+        return bool(re.fullmatch(self.name, name))
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `Subject.matches()` using `re.fullmatch` so that `Subject.name` values are treated as regular expressions during OAuth authentication. Plain names like "alice" continue to work unchanged since they are valid literal regexes.

  - `github-user` / `github-app`: name is matched as a regex against the authenticated user's login or app slug (e.g. ^my-bot-.* is now supported)
  - `github-org` / `github-team`: unaffected — name still identifies the org/team to query via the GitHub API; membership is resolved by exact identity

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/37

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```feature operator
Adds support for regex patterns in OAuth subject name fields for `github-user` and `github-app` types, enabling flexible principal matching (e.g. ^my-bot-.*)
```
