### PR TITLE
enh(sbom): Add `json` suffix to sbom files

### DIFF
--- a/components.py
+++ b/components.py
@@ -1243,7 +1243,7 @@ class DownloadSBOM(aiohttp.web.View):
           Streams a tar archive containing the SBOM documents for all artefacts included in the given
           component (and its transitive dependencies). Artefacts which do not (yet) have an existing
           SBOM document are being skipped without notice. Each entry in the archive is placed under a
-          directory named `<component_name>_<component_version>/<artefact_name>_<artefact_type>`.
+          directory named `<component_name>_<component_version>/<artefact_name>_<artefact_type>.json`
         tags:
         - Components
         parameters:
@@ -1388,7 +1388,7 @@ class DownloadSBOM(aiohttp.web.View):
                     artefact_file += f'_{artefact.normalised_artefact_extra_id}'
                 artefact_file = artefact_file.replace('/', '_').replace(':', '_')
 
-                tarinfo = tarfile.TarInfo(name=f'{component_dir}/{artefact_file}')
+                tarinfo = tarfile.TarInfo(name=f'{component_dir}/{artefact_file}.json')
                 tarinfo.size = blob_metadata.size
 
                 tarinfo_bytes = tarinfo.tobuf()


### PR DESCRIPTION
Convenient for humans interacting with the sbom documents.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy user
SBoM documents now feature an ".json" suffix
```
