### PR TITLE
Install Syft to oci-image

### DIFF
--- a/Dockerfile.extensions
+++ b/Dockerfile.extensions
@@ -10,6 +10,7 @@ RUN --mount=type=bind,source=/dist,target=/dist \
     libffi-dev \
     postgresql16-client \
     python3-dev \
+    syft \
 && CFLAGS='-Wno-int-conversion' \
     pip3 install --upgrade --no-cache-dir --find-links ./dist ocm-gear-extensions \
 && apk del --no-cache \


### PR DESCRIPTION
**What this PR does / why we need it**:
The SBOM Generator extension has started using Syft, so we need to install Syft into the SBOM extension’s OCI image.

**Which issue(s) this PR fixes**: 
Fixes https://github.com/open-component-model/open-delivery-gear/issues/32

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```other developer

```
