### PR TITLE
Replace `init_ocm_repository_lookup` with `extended_ocm_repository_lookup`

### DIFF
--- a/artefact_enumerator.py
+++ b/artefact_enumerator.py
@@ -85,24 +85,24 @@ def _iter_ocm_artefacts(
                 ocm_repo=component.ocm_repo,
             )
 
+        ocm_repository_lookup = lookups.extended_ocm_repository_lookup(component.ocm_repo)
+
         for version in versions:
             component_id = ocm.ComponentIdentity(
                 name=component.component_name,
                 version=version,
             )
 
-            if ocm_repo := component.ocm_repo:
-                component_descriptor = component_descriptor_lookup(
-                    component_id,
-                    ocm_repository_lookup=lookups.init_ocm_repository_lookup(ocm_repo),
-                ).component
-            else:
-                component_descriptor = component_descriptor_lookup(component_id).component
+            component_descriptor = component_descriptor_lookup(
+                component_id,
+                ocm_repository_lookup=ocm_repository_lookup,
+            )
 
             for artefact_node in ocm.iter.iter(
                 component=component_descriptor,
                 lookup=component_descriptor_lookup,
                 node_filter=ocm.iter.Filter.artefacts,
+                ocm_repo=ocm_repository_lookup,
             ):
                 yield odg.model.component_artefact_id_from_ocm(
                     component=artefact_node.component,

--- a/artefacts.py
+++ b/artefacts.py
@@ -91,7 +91,7 @@ class ArtefactBlob(aiohttp.web.View):
         try:
             component_descriptor = await component_descriptor_lookup(
                 component_id,
-                ocm_repository_lookup=lookups.init_ocm_repository_lookup(ocm_repository),
+                ocm_repository_lookup=lookups.extended_ocm_repository_lookup(ocm_repository),
             )
             component = component_descriptor.component
         except oci.model.OciImageNotFoundException:

--- a/compliance_summary/__init__.py
+++ b/compliance_summary/__init__.py
@@ -262,15 +262,12 @@ async def component_datatype_summaries(
     ocm_repo: ocm.OciOcmRepository | None = None,
     shortcut_cache: bool = False,
 ) -> list[tuple[odg.model.ComponentArtefactId, ComplianceSummaryEntry]]:
-    if ocm_repo:
-        component = (
-            await component_descriptor_lookup(
-                component,
-                ocm_repository_lookup=lookups.init_ocm_repository_lookup(ocm_repo),
-            )
-        ).component
-    else:
-        component = (await component_descriptor_lookup(component)).component
+    component = (
+        await component_descriptor_lookup(
+            component,
+            ocm_repository_lookup=lookups.extended_ocm_repository_lookup(ocm_repo),
+        )
+    ).component
 
     artefact_scan_infos = await deliverydb.util.findings_for_component(
         component=component,

--- a/components.py
+++ b/components.py
@@ -129,7 +129,7 @@ async def _component_descriptor(
         version=version,
     )
 
-    ocm_repository_lookup = lookups.init_ocm_repository_lookup(ocm_repo_url)
+    ocm_repository_lookup = lookups.extended_ocm_repository_lookup(ocm_repo)
     ocm_repos = list(ocm_repository_lookup(component_name))
 
     if raw or ignore_cache:
@@ -176,7 +176,7 @@ async def _component_descriptor(
         descriptor = await util.retrieve_component_descriptor(
             component_id,
             component_descriptor_lookup=component_descriptor_lookup,
-            ocm_repository_lookup=lookups.init_ocm_repository_lookup(ocm_repo),
+            ocm_repository_lookup=ocm_repository_lookup,
         )
     except dacite.exceptions.MissingValueError as e:
         raise aiohttp.web.HTTPFailedDependency(
@@ -746,13 +746,15 @@ async def resolve_component_dependencies(
     ocm_repo: ocm.OcmRepository = None,
     recursion_depth: int = -1,
 ) -> collections.abc.AsyncGenerator[ocm.iter.ComponentNode, None, None]:
+    ocm_repository_lookup = lookups.extended_ocm_repository_lookup(ocm_repo)
+
     component_descriptor = await util.retrieve_component_descriptor(
         ocm.ComponentIdentity(
             name=component_name,
             version=component_version,
         ),
         component_descriptor_lookup=component_descriptor_lookup,
-        ocm_repository_lookup=lookups.init_ocm_repository_lookup(ocm_repo),
+        ocm_repository_lookup=ocm_repository_lookup,
     )
     component = component_descriptor.component
 
@@ -763,6 +765,7 @@ async def resolve_component_dependencies(
             recursion_depth=recursion_depth,
             prune_unique=False,
             node_filter=ocm.iter.Filter.components,
+            ocm_repo=ocm_repository_lookup,
         ):
             # add repo classification label if not present in component labels
             label_present = False
@@ -874,7 +877,7 @@ class UpgradePRs(aiohttp.web.View):
                     version=component_version,
                 ),
                 component_descriptor_lookup=self.request.app[consts.APP_COMPONENT_DESCRIPTOR_LOOKUP],
-                ocm_repository_lookup=lookups.init_ocm_repository_lookup(ocm_repo),
+                ocm_repository_lookup=lookups.extended_ocm_repository_lookup(ocm_repo),
             )
             component = component_descriptor.component
             source = cnudie.util.main_source(
@@ -1301,13 +1304,15 @@ class DownloadSBOM(aiohttp.web.View):
                 db_session=db_session,
             )
 
+        ocm_repository_lookup = lookups.extended_ocm_repository_lookup(ocm_repo)
+
         component_descriptor = await util.retrieve_component_descriptor(
             ocm.ComponentIdentity(
                 name=component_name,
                 version=version,
             ),
             component_descriptor_lookup=component_descriptor_lookup,
-            ocm_repository_lookup=lookups.init_ocm_repository_lookup(ocm_repo),
+            ocm_repository_lookup=ocm_repository_lookup,
         )
         component = component_descriptor.component
 
@@ -1319,6 +1324,7 @@ class DownloadSBOM(aiohttp.web.View):
                 lookup=component_descriptor_lookup,
                 recursion_depth=recursion_depth,
                 node_filter=ocm.iter.Filter.artefacts,
+                ocm_repo=ocm_repository_lookup,
             ):
                 if isinstance(artefact_node.artefact, ocm.Resource):
                     artefact_kind = odg.model.ArtefactKind.RESOURCE

--- a/lookups.py
+++ b/lookups.py
@@ -368,6 +368,34 @@ def init_ocm_repository_lookup(
     return ocm_repository_lookup
 
 
+def extended_ocm_repository_lookup(
+    ocm_repo: ocm.OciOcmRepository | str | None = None,
+    ocm_repository_lookup: cnudie.retrieve.OcmRepositoryLookup = None,
+) -> ocm.OcmRepositoryLookup:
+    """
+    Creates an extended OCM repository lookup that also includes the specified `ocm_repo`. Useful
+    in scenarios where an explicit OCM repository is selected, but the default lookup should be
+    still honoured in case the specified OCM repository does not include all required components.
+    """
+    if not ocm_repository_lookup:
+        ocm_repository_lookup = init_ocm_repository_lookup()
+
+    if not ocm_repo:
+        return ocm_repository_lookup
+
+    if isinstance(ocm_repo, ocm.OciOcmRepository):
+        ocm_repo = ocm_repo.oci_ref
+
+    def _ocm_repository_lookup(
+        component: ocm.ComponentName,
+        /,
+    ) -> collections.abc.Iterable[str]:
+        yield ocm_repo
+        yield from ocm_repository_lookup(component)
+
+    return _ocm_repository_lookup
+
+
 @functools.cache
 def semver_sanitising_oci_client(
     secret_factory: secret_mgmt.SecretFactory = None,

--- a/test/test_lookups.py
+++ b/test/test_lookups.py
@@ -105,3 +105,21 @@ def test_ocm_repository_cfgs(
 
     assert len(list(ocm_repository_lookup('ocm.software/ocm-gear/delivery-service'))) == 1
     assert len(list(ocm_repository_lookup('github.com/gardener/gardener'))) == 1
+
+    # test explicitly _added_ repository
+    ocm_repository_lookup = lookups.extended_ocm_repository_lookup(
+        ocm_repo='foo',
+        ocm_repository_lookup=lookups.init_ocm_repository_lookup(
+            ocm_repository_cfgs=ocm_repository_cfgs,
+        ),
+    )
+
+    assert list(ocm_repository_lookup('ocm.software/ocm-gear/delivery-service')) == [
+        'foo',
+        'europe-docker.pkg.dev/gardener-project/releases',
+        'europe-docker.pkg.dev/gardener-project/releases/odg',
+    ]
+    assert list(ocm_repository_lookup('github.com/gardener/gardener')) == [
+        'foo',
+        'europe-docker.pkg.dev/gardener-project/releases',
+    ]


### PR DESCRIPTION
**What this PR does / why we need it**:
The new `extended_ocm_repository_lookup` function prepends an explicitly specified OCM repository to the results of the default lookup, rather than replacing it entirely. This ensures that the default lookup is still honoured when the specified repository does not contain all required components (e.g. during dependency traversal).

Callers in `artefact_enumerator.py`, `artefacts.py`, `compliance_summary/`, and `components.py` are updated accordingly. The `ocm_repo` lookup is also propagated to `ocm.iter.iter` calls so transitive resolution uses the same extended lookup. A unit test is added to verify the prepend behaviour.

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/44

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
An explicitly configured OCM repository is now honoured consistently with a fallback using the default OCM repository lookup
```
