### PR TITLE
breaking(sbom): Switch default generation backend to Syft

### DIFF
--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -1171,7 +1171,7 @@ class SBOMGeneratorConfig(BacklogItemMixins):
     output_format: SbomFormat = SbomFormat.CYCLONEDX
     processing_mode: bdba.model.ProcessingMode = bdba.model.ProcessingMode.FORCE_UPLOAD
     interval: int = 60 * 60 * 24  # 24h
-    generation_mode: odg.model.SbomGenerationMode = odg.model.SbomGenerationMode.BDBA
+    generation_mode: odg.model.SbomGenerationMode = odg.model.SbomGenerationMode.SYFT
 
     def is_supported(
         self,


### PR DESCRIPTION
Prefer backend without external dependencies.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```breaking operator
Syft will now be used by default to generate SBoMs (BDBA still available via configuration)
```
