### PR TITLE
enh(issues): Improve readability for short github issues

### DIFF
--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -248,7 +248,8 @@ def findings_summary(
     finding_name = finding_cfg.type.removeprefix('finding/')
     summary_long = summary = summary_short = f'# Summary of found {finding_name} findings\n'
 
-    for finding_group in finding_groups:
+    total_groups = len(finding_groups)
+    for idx, finding_group in enumerate(finding_groups, start=1):
         # only show rescoring URL in case there are actually open findings to rescore
         show_delivery_dashboard_url = bool(finding_group.findings)
         group_summary_long, group_summary, group_summary_short = finding_group.summary(
@@ -287,7 +288,8 @@ def findings_summary(
         if group_summary:
             summary += f'{group_summary}\n---\n'
         if group_summary_short:
-            summary_short += f'{group_summary_short}\n---\n'
+            # add counter to short summary for better navigation
+            summary_short += f'**[{idx}/{total_groups}]** {group_summary_short}\n---\n'
 
     return summary_long, summary, summary_short
 


### PR DESCRIPTION
With the minimalistic summary, it is hard for an end-user to keep track what entry they are currently looking at, considering all entries look the same.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy user
GitHub issues with shorten text will now feature a counter improving readability and navigation.
```
