### PR TITLE
fix: Consistently use Helm chart name instead of image mapping name

### DIFF
--- a/odg_operator/odg_model.py
+++ b/odg_operator/odg_model.py
@@ -212,7 +212,7 @@ class ExtensionInstance:
                 for path, value in image_mappings.items():
                     installation_values.append(
                         ExtensionInstanceValue(
-                            helm_chart_name=mapping.name,
+                            helm_chart_name=ocm_ref.helm_chart_name,
                             helm_attribute=path,
                             value=value,
                         ),


### PR DESCRIPTION
**What this PR does / why we need it**:
The previously applied fix 53168fec67d5c0897507d39b5fd34f46be9884a9 apparently missed this occurrency where the artefact name of the image mapping was still used instead of the explicitly configured Helm chart name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
Consistently use Helm chart name instead of image mapping name
```
