### PR TITLE
Introduce artefact-type filter in SBoM generator

### DIFF
--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -1177,6 +1177,7 @@ class SBOMGeneratorConfig(BacklogItemMixins):
         self,
         artefact_kind: odg.model.ArtefactKind | None = None,
         access_type: ocm.AccessType | None = None,
+        artefact_type: ocm.ArtefactType | None = None,
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.RESOURCE,)
 
@@ -1186,6 +1187,13 @@ class SBOMGeneratorConfig(BacklogItemMixins):
                 ocm.AccessType.OCI_REGISTRY,
                 ocm.AccessType.LOCAL_BLOB,
                 ocm.AccessType.S3,
+            ),
+        }
+
+        supported_artefact_types_by_mode = {
+            odg.model.SbomGenerationMode.SYFT: (
+                ocm.ArtefactType.OCI_IMAGE,
+                ocm.ArtefactType.DIRECTORY_TREE,
             ),
         }
 
@@ -1207,6 +1215,16 @@ class SBOMGeneratorConfig(BacklogItemMixins):
                     logger.warning(
                         f'{access_type=} is not supported for SBOM Generation '
                         f'with {self.generation_mode=}, {supported_access_types=}',
+                    )
+
+        if artefact_type:
+            supported_artefact_types = supported_artefact_types_by_mode.get(self.generation_mode, ())
+            if supported_artefact_types and artefact_type not in supported_artefact_types:
+                is_supported = False
+                if self.on_unsupported is WarningVerbosities.WARNING:
+                    logger.warning(
+                        f'{artefact_type=} is not supported for SBOM Generation '
+                        f'with {self.generation_mode=}, {supported_artefact_types=}',
                     )
 
         return is_supported

--- a/sbom_generator.py
+++ b/sbom_generator.py
@@ -191,13 +191,15 @@ def generate_sbom_for_artefact(
     if not extension_cfg.is_supported(
         artefact_kind=artefact.artefact_kind,
         access_type=resource_node.resource.access.type,
+        artefact_type=resource_node.resource.type,
     ):
         if extension_cfg.on_unsupported is odg.extensions_cfg.WarningVerbosities.FAIL:
             raise TypeError(
-                f'{artefact.artefact_kind} / {resource_node.resource.access.type} is not '
+                f'{artefact.artefact_kind} / {resource_node.resource.access.type} / '
+                f'{resource_node.resource.type} is not '
                 'supported by the SBOM Generator extension, '
                 'maybe the filter configurations have to be adjusted '
-                'to filter out this artefact kind or access type',
+                'to filter out this artefact kind, access type, or artefact type',
             )
         return
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Syft only supports container images and filesystems, so we need to filter out unsupported artifacts.
 
**Which issue(s) this PR fixes**:
Fixes # https://github.com/open-component-model/open-delivery-gear/issues/59

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement developer
Introduce artefact-type filter in SBoM generator
```
