### PR TITLE
Ensure `delivery-gear-utils` package is installed in correct version

### DIFF
--- a/setup.extensions.py
+++ b/setup.extensions.py
@@ -9,7 +9,8 @@ own_dir = os.path.abspath(os.path.dirname(__file__))
 
 
 def requirements():
-    yield 'delivery-gear-utils'
+    version = os.environ.get('ODG_UTILS_PACKAGE_VERSION', setup.finalize_version())
+    yield f'delivery-gear-utils=={version}'
 
     with open(os.path.join(own_dir, 'requirements.extensions.txt')) as f:
         for line in f.readlines():

--- a/setup.service.py
+++ b/setup.service.py
@@ -9,7 +9,8 @@ own_dir = os.path.abspath(os.path.dirname(__file__))
 
 
 def requirements():
-    yield 'delivery-gear-utils'
+    version = os.environ.get('ODG_UTILS_PACKAGE_VERSION', setup.finalize_version())
+    yield f'delivery-gear-utils=={version}'
 
     with open(os.path.join(own_dir, 'requirements.service.txt')) as f:
         for line in f.readlines():


### PR DESCRIPTION
**What this PR does / why we need it**:
It has shown that there might be cases in which an earlier version is used instead of the currently built version (e.g. [here](https://github.com/open-component-model/delivery-service/actions/runs/24836324451/job/72697794244) `0.1265.0` instead of `0.1317.0`).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
Ensure correct (current) version of `delivery-gear-utils` Python package is installed
```
