### PR TITLE
Add `ignore_lookup` param to skip OCM repository lookup fallback

### DIFF
--- a/components.py
+++ b/components.py
@@ -115,6 +115,12 @@ async def _component_descriptor(
     version = util.param(params, 'version', default='greatest')
     raw = util.param_as_bool(params, 'raw')
     ignore_cache = util.param_as_bool(params, 'ignore_cache')
+    ignore_lookup = util.param_as_bool(params, 'ignore_lookup')
+
+    if ignore_lookup and not ocm_repo:
+        raise aiohttp.web.HTTPBadRequest(
+            text='If `ignore_lookup` is true, an `ocm_repo_url` must be specified explicitly',
+        )
 
     if version == 'greatest':
         version = await greatest_version_if_none(
@@ -129,7 +135,11 @@ async def _component_descriptor(
         version=version,
     )
 
-    ocm_repository_lookup = lookups.extended_ocm_repository_lookup(ocm_repo)
+    if ignore_lookup:
+        ocm_repository_lookup = cnudie.retrieve.ocm_repository_lookup(ocm_repo)
+    else:
+        ocm_repository_lookup = lookups.extended_ocm_repository_lookup(ocm_repo)
+
     ocm_repos = list(ocm_repository_lookup(component_name))
 
     if raw or ignore_cache:
@@ -217,6 +227,12 @@ class Component(aiohttp.web.View):
             default: false
         - in: query
           name: ignore_cache
+          required: false
+          schema:
+            type: boolean
+            default: false
+        - in: query
+          name: ignore_lookup
           required: false
           schema:
             type: boolean
@@ -385,6 +401,12 @@ class ComponentResponsibles(aiohttp.web.View):
             default: false
         - in: query
           name: ignore_cache
+          required: false
+          schema:
+            type: boolean
+            default: false
+        - in: query
+          name: ignore_lookup
           required: false
           schema:
             type: boolean

--- a/delivery/client.py
+++ b/delivery/client.py
@@ -309,11 +309,13 @@ class DeliveryServiceClient:
         version: str,
         ocm_repo_url: str = None,
         version_filter: str | None = None,
+        ignore_lookup: bool = False,
         validation_mode: ocm.ValidationMode | None = None,
     ):
         params = {
             'component_name': name,
             'version': version,
+            'ignore_lookup': ignore_lookup,
         }
         if ocm_repo_url:
             params['ocm_repo_url'] = ocm_repo_url

--- a/odg_client/__init__.py
+++ b/odg_client/__init__.py
@@ -310,11 +310,13 @@ class DeliveryServiceClient:
         version: str,
         ocm_repo_url: str = None,
         version_filter: str | None = None,
+        ignore_lookup: bool = False,
         validation_mode: ocm.ValidationMode | None = None,
     ):
         params = {
             'component_name': name,
             'version': version,
+            'ignore_lookup': ignore_lookup,
         }
         if ocm_repo_url:
             params['ocm_repo_url'] = ocm_repo_url


### PR DESCRIPTION
**What this PR does / why we need it**:
Since https://github.com/open-component-model/delivery-service/pull/745, an OCM component descriptor might be retrieved from a different OCM repository than the explicitly configured one in case it is not found there. This is problematic in case one wants to check whether the component descriptor is existing in a certain repository or not (e.g. prior to a replication). To forcefully only lookup in the specified repository, add a new `ignore_lookup` param (consistent to the existing `ignore_cache` param) which skips the built-in lookup logic.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement developer
Added a new `ignore_lookup` param to fetch OCM component descriptors to skip built-in OCM repository fallback lookup and only honour explicitly configured `ocm_repo_url`
```
