### PR TITLE
Don't use dedicated containers in GitHub-Actions

### DIFF
--- a/.github/workflows/build-bdba.yaml
+++ b/.github/workflows/build-bdba.yaml
@@ -112,8 +112,6 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    container:
-      image: python:3.12-alpine
     needs:
       - packages
     permissions:
@@ -126,14 +124,6 @@ jobs:
           name: distribution-packages
       - name: lint
         run: |
-          echo "install dependencies for python-packages"
-
-          if ! apk add --no-cache $(cat apk-packages) >/tmp/apk.log; then
-            echo "error while trying to install apk-packages:"
-            cat /tmp/apk.log
-            exit 1
-          fi
-
           tar xf distribution-packages.tar.gz -C /tmp
 
           echo "installing linters"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -181,8 +181,6 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    container:
-      image: python:3.12-alpine
     needs:
       - packages
     permissions:
@@ -195,14 +193,6 @@ jobs:
           name: distribution-packages
       - name: lint
         run: |
-          echo "install dependencies for python-packages"
-
-          if ! apk add --no-cache $(cat apk-packages) >/tmp/apk.log; then
-            echo "error while trying to install apk-packages:"
-            cat /tmp/apk.log
-            exit 1
-          fi
-
           tar xf distribution-packages.tar.gz -C /tmp
 
           echo "installing linters"
@@ -257,8 +247,6 @@ jobs:
 
   unittests:
     runs-on: ubuntu-latest
-    container:
-      image: alpine
     needs:
       - packages
     permissions:
@@ -271,14 +259,6 @@ jobs:
           name: distribution-packages
       - name: run-tests
         run: |
-          echo "install dependencies for python-packages"
-
-          if ! apk add --no-cache $(cat apk-packages) >/tmp/apk.log; then
-            echo "error while trying to install apk-packages:"
-            cat /tmp/apk.log
-            exit 1
-          fi
-
           tar xf distribution-packages.tar.gz -C /tmp
 
           echo "installing packages"

--- a/.github/workflows/publish_development_kit.yaml
+++ b/.github/workflows/publish_development_kit.yaml
@@ -16,15 +16,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: python:alpine
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Install git, setuptools, and semver
         run: |
-          apk add \
-            git
           pip3 install \
             setuptools \
             semver


### PR DESCRIPTION
**What this PR does / why we need it**:
Running the jobs in dedicated containers turned out to cause some unexpected issues, last but not least it broke some assumptions about the existence of files of checked out actions, see for example: https://github.com/open-component-model/delivery-service/actions/runs/25148575419/job/73713750685

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator

```
