### PR TITLE
Keep `.metadata.annotations` when replacing resources in ODG operator

### DIFF
--- a/odg_operator/__main__.py
+++ b/odg_operator/__main__.py
@@ -195,9 +195,17 @@ def create_or_update_resource(
             if isinstance(resource, dict):
                 resource_version = resource['metadata']['resourceVersion']
             else:
-                resource_version = resource.to_dict()['metadata']['resource_version']
+                resource = resource.to_dict()
+                resource_version = resource['metadata']['resource_version']
+
+            existing_annotations = resource['metadata'].get('annotations') or {}
+            desired_annotations = data['metadata'].get('annotations') or {}
 
             data['metadata']['resourceVersion'] = resource_version
+            data['metadata']['annotations'] = {
+                **existing_annotations,
+                **desired_annotations,
+            }
 
             kwargs['body'] = data
             replace_namespaced_resource(**kwargs)


### PR DESCRIPTION
**What this PR does / why we need it**:
Especially necessary to keep (manual) annotations set to control the behaviour of the Gardener Resource Manager (i.e. the "ignore" flag).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator
Keep `.metadata.annotations` when replacing resources in ODG operator
```
