### PR TITLE
breaking(bdba): Drop artefact UUID suffix again

### DIFF
--- a/bdba_utils/scan.py
+++ b/bdba_utils/scan.py
@@ -10,7 +10,6 @@ import ocm
 import ocm.iter
 
 import bdba.client
-import bdba.limits
 import bdba.model as bm
 import bdba_utils.assessments
 import bdba_utils.rescore
@@ -19,7 +18,6 @@ import bdba_utils.model
 import odg.findings
 import odg.labels
 import odg.model
-import odg.util
 import odg_client
 import ocm_util
 import secret_mgmt
@@ -43,7 +41,6 @@ class ResourceGroupProcessor:
         resource_node: ocm.iter.ResourceNode,
         content_iterator: collections.abc.Generator[bytes, None, None],
         known_artefact_scans: collections.abc.Iterable[bm.Product],
-        delivery_service_client: odg_client.DeliveryServiceClient,
     ) -> bdba_utils.model.ScanRequest:
         component = resource_node.component
         resource = resource_node.resource
@@ -54,21 +51,6 @@ class ResourceGroupProcessor:
         if resource.extraIdentity:
             # peers are not required here as version is considered anyways
             display_name += '_' + normalize_display_name(value=f'{resource.identity(peers=())}')
-
-        uuid_for_artefact = odg.util.uuid_for_artefact_id(
-            artefact_id=odg.model.component_artefact_id_from_ocm(
-                component=resource_node.component,
-                artefact=resource_node.resource,
-            ),
-            delivery_service_client=delivery_service_client,
-        )
-
-        # ensure UUID is not truncated
-        display_name = bdba.limits.trim(
-            display_name,
-            (bdba.limits.app_name - len(str(uuid_for_artefact)) - 1),  # uuid and trailing underscore
-        )
-        display_name += f'_{str(uuid_for_artefact)}'
 
         component_artefact_metadata = bdba_utils.util.component_artefact_metadata(
             resource_node=resource_node,
@@ -206,7 +188,6 @@ class ResourceGroupProcessor:
             resource_node=resource_node,
             content_iterator=content_iterator,
             known_artefact_scans=known_scan_results,
-            delivery_service_client=delivery_service_client,
         )
         try:
             result = self.process_scan_request(


### PR DESCRIPTION
With https://github.com/open-component-model/open-delivery-gear/pull/65 the BDBA suffix is not required anymore.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```breaking developer
BDBA scans no longer feature an UUID suffix
```
