### PR TITLE
refactor(sbom): Factor out sbom generation for artefact

### DIFF
--- a/crypto_extension/cbom.py
+++ b/crypto_extension/cbom.py
@@ -72,10 +72,11 @@ def find_cbom_or_create(
         filename_for_access_type = {
             ocm.AccessType.LOCAL_BLOB: 'local_blob',
             ocm.AccessType.S3: 's3',
-            ocm.AccessType.OCI_REGISTRY: None, # unused
         }
-        sbom_path = os.path.join(tmp_dir, 'sbom')
-        file_path = os.path.join(tmp_dir, filename_for_access_type[access.type])
+
+        file_path = None
+        if filename := filename_for_access_type.get(access.type):
+            file_path = os.path.join(tmp_dir, filename)
 
         sbom_raw = syft.generate_raw_sbom_for_artefact(
             component=component,
@@ -83,8 +84,10 @@ def find_cbom_or_create(
             secret_factory=secret_factory,
             oci_client=oci_client,
             aws_secret_name=mapping.aws_secret_name,
+            file_path=file_path,
         )
 
+        sbom_path = os.path.join(tmp_dir, 'sbom')
         with open(sbom_path, 'w') as file:
             file.write(sbom_raw)
 

--- a/crypto_extension/cbom.py
+++ b/crypto_extension/cbom.py
@@ -2,18 +2,14 @@ import json
 import logging
 import os
 import subprocess
-import tarfile
 import tempfile
 
 import oci.client
 import ocm
 
 import syft
-import dockerutil
 import odg.extensions_cfg
 import secret_mgmt
-import secret_mgmt.aws
-import secret_mgmt.oci_registry
 
 
 logger = logging.getLogger(__name__)
@@ -72,111 +68,36 @@ def find_cbom_or_create(
     Looks up an existing CBOM document (to be implemented once it is aligned on target picture) or
     creates a CBOM ad-hoc using `syft` and `cbomkit-theia`.
     """
-    if access.type is ocm.AccessType.OCI_REGISTRY:
-        oci_secret = secret_mgmt.oci_registry.find_cfg(
+    with tempfile.TemporaryDirectory(dir=own_dir) as tmp_dir:
+        filename_for_access_type = {
+            ocm.AccessType.LOCAL_BLOB: 'local_blob',
+            ocm.AccessType.S3: 's3',
+            ocm.AccessType.OCI_REGISTRY: 'oci_registry',
+        }
+        sbom_path = os.path.join(tmp_dir, 'sbom')
+        file_path = os.path.join(tmp_dir, filename_for_access_type[access.type])
+
+        sbom_raw = syft.generate_raw_sbom_for_artefact(
+            component=component,
+            access=access,
             secret_factory=secret_factory,
-            image_reference=access.imageReference,
+            oci_client=oci_client,
+            aws_secret_name=mapping.aws_secret_name,
         )
 
-        if oci_secret:
-            dockerutil.prepare_docker_cfg(
-                image_reference=access.imageReference,
-                username=oci_secret.username,
-                password=oci_secret.password,
-            )
+        with open(sbom_path, 'w') as file:
+            file.write(sbom_raw)
 
-        with tempfile.TemporaryDirectory(dir=own_dir) as tmp_dir:
-            sbom_path = os.path.join(tmp_dir, 'sbom')
-
-            sbom_raw = syft.run_syft(source=access.imageReference)
-
-            with open(sbom_path, 'w') as file:
-                file.write(sbom_raw)
-
+        if access.type is ocm.AccessType.OCI_REGISTRY:
             cbom = create_cbom(
                 image=access.imageReference,
                 sbom_path=sbom_path,
             )
 
-    elif access.type is ocm.AccessType.S3:
-        aws_secret = secret_mgmt.aws.find_cfg(
-            secret_factory=secret_factory,
-            secret_name=mapping.aws_secret_name,
-        )
-        s3_client = aws_secret.session.client('s3')
-
-        if isinstance(access, ocm.LegacyS3Access):
-            bucket = access.bucketName
-            key = access.objectKey
         else:
-            bucket = access.bucket
-            key = access.key
-
-        fileobj = s3_client.get_object(Bucket=bucket, Key=key)['Body']
-
-        def tar_filter(member: tarfile.TarInfo, dest_path: str) -> tarfile.TarInfo | None:
-            if member.islnk() or member.issym():
-                if os.path.isabs(member.linkname):
-                    return None
-            return member
-
-        with tempfile.TemporaryDirectory(dir=own_dir) as tmp_dir:
-            sbom_path = os.path.join(tmp_dir, 'sbom')
-            s3_path = os.path.join(tmp_dir, 's3')
-
-            with tarfile.open(fileobj=fileobj, mode='r|*') as tar:
-                tar.extractall(
-                    path=s3_path,
-                    filter=tar_filter,
-                )
-
-            sbom_raw = syft.run_syft(source=s3_path)
-
-            with open(sbom_path, 'w') as file:
-                file.write(sbom_raw)
-
             cbom = create_cbom(
-                dir=s3_path,
+                dir=file_path,
                 sbom_path=sbom_path,
             )
-
-    elif access.type is ocm.AccessType.LOCAL_BLOB:
-        if access.globalAccess:
-            image_reference = access.globalAccess.ref
-            digest = access.globalAccess.digest
-        else:
-            image_reference = component.current_ocm_repo.component_version_oci_ref(
-                name=component.name,
-                version=component.version,
-            )
-            digest = access.localReference
-
-        blob = oci_client.blob(
-            image_reference=image_reference,
-            digest=digest,
-            stream=True,
-        )
-
-        with tempfile.TemporaryDirectory(dir=own_dir) as tmp_dir:
-            sbom_path = os.path.join(tmp_dir, 'sbom')
-            local_blob_path = os.path.join(tmp_dir, 'local_blob')
-
-            with open(local_blob_path, 'wb') as file:
-                for chunk in blob.iter_content(chunk_size=4096):
-                    file.write(chunk)
-
-            sbom_raw = syft.run_syft(source=local_blob_path)
-
-            with open(sbom_path, 'w') as file:
-                file.write(sbom_raw)
-
-            cbom = create_cbom(
-                dir=local_blob_path,
-                sbom_path=sbom_path,
-            )
-
-    else:
-        # we filtered supported access types already earlier
-        raise RuntimeError('this is a bug, this line should never be reached')
 
     return cbom

--- a/crypto_extension/cbom.py
+++ b/crypto_extension/cbom.py
@@ -72,7 +72,7 @@ def find_cbom_or_create(
         filename_for_access_type = {
             ocm.AccessType.LOCAL_BLOB: 'local_blob',
             ocm.AccessType.S3: 's3',
-            ocm.AccessType.OCI_REGISTRY: 'oci_registry',
+            ocm.AccessType.OCI_REGISTRY: None, # unused
         }
         sbom_path = os.path.join(tmp_dir, 'sbom')
         file_path = os.path.join(tmp_dir, filename_for_access_type[access.type])

--- a/syft.py
+++ b/syft.py
@@ -55,9 +55,10 @@ def run_syft(
 def generate_raw_sbom_for_artefact(
     component: ocm.Component,
     access: ocm.Access,
-    secret_factory,
+    secret_factory: secret_mgmt.SecretFactory,
     oci_client: oci.client.Client,
     aws_secret_name: str | None = None,
+    sbom_output_format: SyftSbomFormat = SyftSbomFormat.CYCLONEDX,
 ) -> str:
     if access.type is ocm.AccessType.OCI_REGISTRY:
         access: ocm.OciAccess
@@ -74,7 +75,10 @@ def generate_raw_sbom_for_artefact(
                 password=oci_secret.password,
             )
 
-        return run_syft(source=access.imageReference)
+        return run_syft(
+            source=access.imageReference,
+            output_format=sbom_output_format,
+        )
 
     elif access.type is ocm.AccessType.S3:
         access: ocm.S3Access
@@ -109,7 +113,10 @@ def generate_raw_sbom_for_artefact(
                     filter=tar_filter,
                 )
 
-            return run_syft(source=s3_path)
+            return run_syft(
+                source=s3_path,
+                output_format=sbom_output_format,
+            )
 
     elif access.type is ocm.AccessType.LOCAL_BLOB:
         access: ocm.LocalBlobAccess | ocm.LocalBlobGlobalAccess
@@ -137,7 +144,10 @@ def generate_raw_sbom_for_artefact(
                 for chunk in blob.iter_content(chunk_size=4096):
                     file.write(chunk)
 
-            return run_syft(source=local_blob_path)
+            return run_syft(
+                source=local_blob_path,
+                output_format=sbom_output_format,
+            )
 
     else:
         raise ValueError(f'dont know how to handle {access.type=}')

--- a/syft.py
+++ b/syft.py
@@ -1,9 +1,20 @@
 import enum
 import logging
+import os
 import subprocess
+import tarfile
+import tempfile
+
+import oci.client
+import ocm
+
+import dockerutil
+import secret_mgmt.aws
+import secret_mgmt.oci_registry
 
 
 logger = logging.getLogger(__name__)
+own_dir = os.path.abspath(os.path.dirname(__file__))
 
 
 class SyftSbomFormat(enum.StrEnum):
@@ -39,3 +50,94 @@ def run_syft(
         raise
 
     return sbom_raw
+
+
+def generate_raw_sbom_for_artefact(
+    component: ocm.Component,
+    access: ocm.Access,
+    secret_factory,
+    oci_client: oci.client.Client,
+    aws_secret_name: str | None = None,
+) -> str:
+    if access.type is ocm.AccessType.OCI_REGISTRY:
+        access: ocm.OciAccess
+
+        oci_secret = secret_mgmt.oci_registry.find_cfg(
+            secret_factory=secret_factory,
+            image_reference=access.imageReference,
+        )
+
+        if oci_secret:
+            dockerutil.prepare_docker_cfg(
+                image_reference=access.imageReference,
+                username=oci_secret.username,
+                password=oci_secret.password,
+            )
+
+        return run_syft(source=access.imageReference)
+
+    elif access.type is ocm.AccessType.S3:
+        access: ocm.S3Access
+
+        aws_secret = secret_mgmt.aws.find_cfg(
+            secret_factory=secret_factory,
+            secret_name=aws_secret_name,
+        )
+        s3_client = aws_secret.session.client('s3')
+
+        if isinstance(access, ocm.LegacyS3Access):
+            bucket = access.bucketName
+            key = access.objectKey
+        else:
+            bucket = access.bucket
+            key = access.key
+
+        fileobj = s3_client.get_object(Bucket=bucket, Key=key)['Body']
+
+        def tar_filter(member: tarfile.TarInfo, dest_path: str) -> tarfile.TarInfo | None:
+            if member.islnk() or member.issym():
+                if os.path.isabs(member.linkname):
+                    return None
+            return member
+
+        with tempfile.TemporaryDirectory(dir=own_dir) as tmp_dir:
+            s3_path = os.path.join(tmp_dir, 's3')
+
+            with tarfile.open(fileobj=fileobj, mode='r|*') as tar:
+                tar.extractall(
+                    path=s3_path,
+                    filter=tar_filter,
+                )
+
+            return run_syft(source=s3_path)
+
+    elif access.type is ocm.AccessType.LOCAL_BLOB:
+        access: ocm.LocalBlobAccess | ocm.LocalBlobGlobalAccess
+
+        if access.globalAccess:
+            image_reference = access.globalAccess.ref
+            digest = access.globalAccess.digest
+        else:
+            image_reference = component.current_ocm_repo.component_version_oci_ref(
+                name=component.name,
+                version=component.version,
+            )
+            digest = access.localReference
+
+        blob = oci_client.blob(
+            image_reference=image_reference,
+            digest=digest,
+            stream=True,
+        )
+
+        with tempfile.TemporaryDirectory(dir=own_dir) as tmp_dir:
+            local_blob_path = os.path.join(tmp_dir, 'local_blob')
+
+            with open(local_blob_path, 'wb') as file:
+                for chunk in blob.iter_content(chunk_size=4096):
+                    file.write(chunk)
+
+            return run_syft(source=local_blob_path)
+
+    else:
+        raise ValueError(f'dont know how to handle {access.type=}')

--- a/syft.py
+++ b/syft.py
@@ -60,6 +60,16 @@ def generate_raw_sbom_for_artefact(
     aws_secret_name: str | None = None,
     sbom_output_format: SyftSbomFormat = SyftSbomFormat.CYCLONEDX,
 ) -> str:
+    if (
+        access.type
+        in (
+            ocm.AccessType.LOCAL_BLOB,
+            ocm.AccessType.S3,
+        )
+        and not file_path
+    ):
+        raise ValueError(f'file_path must not be empty for {access.type=}')
+
     if access.type is ocm.AccessType.OCI_REGISTRY:
         access: ocm.OciAccess
 

--- a/syft.py
+++ b/syft.py
@@ -3,7 +3,6 @@ import logging
 import os
 import subprocess
 import tarfile
-import tempfile
 
 import oci.client
 import ocm
@@ -57,6 +56,7 @@ def generate_raw_sbom_for_artefact(
     access: ocm.Access,
     secret_factory: secret_mgmt.SecretFactory,
     oci_client: oci.client.Client,
+    file_path: str | None = None,
     aws_secret_name: str | None = None,
     sbom_output_format: SyftSbomFormat = SyftSbomFormat.CYCLONEDX,
 ) -> str:
@@ -104,19 +104,16 @@ def generate_raw_sbom_for_artefact(
                     return None
             return member
 
-        with tempfile.TemporaryDirectory(dir=own_dir) as tmp_dir:
-            s3_path = os.path.join(tmp_dir, 's3')
-
-            with tarfile.open(fileobj=fileobj, mode='r|*') as tar:
-                tar.extractall(
-                    path=s3_path,
-                    filter=tar_filter,
-                )
-
-            return run_syft(
-                source=s3_path,
-                output_format=sbom_output_format,
+        with tarfile.open(fileobj=fileobj, mode='r|*') as tar:
+            tar.extractall(
+                path=file_path,
+                filter=tar_filter,
             )
+
+        return run_syft(
+            source=file_path,
+            output_format=sbom_output_format,
+        )
 
     elif access.type is ocm.AccessType.LOCAL_BLOB:
         access: ocm.LocalBlobAccess | ocm.LocalBlobGlobalAccess
@@ -137,17 +134,14 @@ def generate_raw_sbom_for_artefact(
             stream=True,
         )
 
-        with tempfile.TemporaryDirectory(dir=own_dir) as tmp_dir:
-            local_blob_path = os.path.join(tmp_dir, 'local_blob')
+        with open(file_path, 'wb') as file:
+            for chunk in blob.iter_content(chunk_size=4096):
+                file.write(chunk)
 
-            with open(local_blob_path, 'wb') as file:
-                for chunk in blob.iter_content(chunk_size=4096):
-                    file.write(chunk)
-
-            return run_syft(
-                source=local_blob_path,
-                output_format=sbom_output_format,
-            )
+        return run_syft(
+            source=file_path,
+            output_format=sbom_output_format,
+        )
 
     else:
         raise ValueError(f'dont know how to handle {access.type=}')


### PR DESCRIPTION
Enable re-use, e.g. in BlackDuck extension, without introducing dependency on crypto extension.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy developer
"syft" module now offers a convenient method to generate SBoM documents for OCM artefacts
```
