### PR TITLE
Revert "Pin `kubernetes` package to resolve circular import"

### DIFF
--- a/requirements.utils.txt
+++ b/requirements.utils.txt
@@ -5,7 +5,7 @@ cachetools
 dacite
 gardener-cicd-libs==1.2756.0
 github3.py
-kubernetes<=35 # there is a circular import in v36 (rc)
+kubernetes
 requests
 urllib3
 watchdog


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit e93befcf4281672ad8a1d2dfd300e8354c64a724.

For reference, see https://github.com/kubernetes-client/python/issues/2564

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator

```
