### PR TITLE
feat(uuid): Optionally, opt-out of widened scope

### DIFF
--- a/odg/util.py
+++ b/odg/util.py
@@ -278,10 +278,50 @@ def process_backlog_items(
             logger.info(f'processed and deleted backlog item {name}')
 
 
+def _convert_none_to_empty_string_for_component_artefact_id(
+    artefact_id: odg.model.ComponentArtefactId,
+) -> odg.model.ComponentArtefactId:
+    """
+    Convert None values to empty strings for string-typed fields in ComponentArtefactId.
+    This is useful as None values have a special semantic in terms of query-metadata, see:
+    https://github.com/open-component-model/delivery-service/blob/d97df8740c26ebd0a696289cc29b93ae4695f75b/deliverydb/util.py#L229
+    """
+    artefact = None
+    if artefact_id.artefact is not None:
+        artefact = odg.model.LocalArtefactId(
+            artefact_name=artefact_id.artefact.artefact_name
+            if artefact_id.artefact.artefact_name is not None
+            else '',
+            artefact_version=artefact_id.artefact.artefact_version
+            if artefact_id.artefact.artefact_version is not None
+            else '',
+            artefact_type=artefact_id.artefact.artefact_type
+            if artefact_id.artefact.artefact_type is not None
+            else '',
+            artefact_extra_id=artefact_id.artefact.artefact_extra_id,
+        )
+
+    references = [
+        _convert_none_to_empty_string_for_component_artefact_id(ref)
+        for ref in artefact_id.references
+    ]
+
+    return odg.model.ComponentArtefactId(
+        component_name=artefact_id.component_name if artefact_id.component_name is not None else '',
+        component_version=artefact_id.component_version
+        if artefact_id.component_version is not None
+        else '',
+        artefact=artefact,
+        artefact_kind=artefact_id.artefact_kind,  # Keep None or enum value as-is
+        references=references,
+    )
+
+
 def uuid_for_artefact_id(
     artefact_id: odg.model.ComponentArtefactId,
     delivery_service_client: odg_client.DeliveryServiceClient,
     skip_verify: bool = False,
+    convert_none_to_empty_string: bool = False,
 ) -> uuid.UUID:
     """
     Retrieve or create a UUID for an artefact.
@@ -297,6 +337,8 @@ def uuid_for_artefact_id(
       delivery_service_client: The DeliveryServiceClient used to query and update
         metadata in the delivery service.
       skip_verify: Whether to check if newly created UUID is fetchable from ODG
+      convert_none_to_empty_string: If True, recursively convert None values
+        in artefact_id (including nested dataclasses) to empty strings
 
     Returns:
       uuid.UUID: The UUID associated with the artefact. Either an existing UUID
@@ -307,6 +349,9 @@ def uuid_for_artefact_id(
       - if the UUID upload verification fails
       - if more than one UUID is found for an artefact
     """
+    if convert_none_to_empty_string:
+        artefact_id = _convert_none_to_empty_string_for_component_artefact_id(artefact_id)
+
     result = delivery_service_client.query_metadata(
         artefacts=[
             artefact_id,

--- a/test/test_odg_util.py
+++ b/test/test_odg_util.py
@@ -1,0 +1,114 @@
+import odg.model
+import odg.util
+
+
+def test_convert_none_to_empty_string():
+    # Test with ComponentArtefactId with None values at multiple levels
+    artefact_id = odg.model.ComponentArtefactId(
+        component_name='my-component',
+        component_version=None,  # None value to be converted
+        artefact_kind=odg.model.ArtefactKind.RESOURCE,
+        artefact=odg.model.LocalArtefactId(
+            artefact_name='my-artefact',
+            artefact_version=None,  # None value to be converted
+            artefact_type='my-artefact-type',
+            artefact_extra_id={},
+        ),
+        references=[
+            odg.model.ComponentArtefactId(
+                component_name=None,  # None value to be converted
+                component_version='1.0.0',
+                artefact=odg.model.LocalArtefactId(
+                    artefact_name='reference-artefact',
+                    artefact_version='2.0.0',
+                    artefact_type=None,  # None value to be converted
+                ),
+            ),
+        ],
+    )
+
+    result = odg.util._convert_none_to_empty_string_for_component_artefact_id(artefact_id)
+
+    # Check top-level None conversion
+    assert result.component_name == 'my-component'
+    assert result.component_version == ''  # was None
+    assert result.artefact_kind == odg.model.ArtefactKind.RESOURCE
+
+    # Check nested artefact None conversion
+    assert result.artefact.artefact_name == 'my-artefact'
+    assert result.artefact.artefact_version == ''  # was None
+    assert result.artefact.artefact_type == 'my-artefact-type'
+
+    # Check references list with nested None conversion
+    assert len(result.references) == 1
+    assert result.references[0].component_name == ''  # was None
+    assert result.references[0].component_version == '1.0.0'
+    assert result.references[0].artefact.artefact_name == 'reference-artefact'
+    assert result.references[0].artefact.artefact_version == '2.0.0'
+    assert result.references[0].artefact.artefact_type == ''  # was None
+
+
+def test_convert_none_to_empty_string_no_none_values():
+    # Test with ComponentArtefactId with no None values
+    artefact_id = odg.model.ComponentArtefactId(
+        component_name='my-component',
+        component_version='1.0.0',
+        artefact_kind=odg.model.ArtefactKind.RESOURCE,
+        artefact=odg.model.LocalArtefactId(
+            artefact_name='my-artefact',
+            artefact_version='2.0.0',
+            artefact_type='my-artefact-type',
+            artefact_extra_id={'key': 'value'},
+        ),
+    )
+
+    result = odg.util._convert_none_to_empty_string_for_component_artefact_id(artefact_id)
+
+    # All values should remain unchanged
+    assert result.component_name == 'my-component'
+    assert result.component_version == '1.0.0'
+    assert result.artefact_kind == odg.model.ArtefactKind.RESOURCE
+    assert result.artefact.artefact_name == 'my-artefact'
+    assert result.artefact.artefact_version == '2.0.0'
+    assert result.artefact.artefact_type == 'my-artefact-type'
+    assert result.artefact.artefact_extra_id == {'key': 'value'}
+
+
+def test_convert_none_to_empty_string_none_artefact():
+    # Test with None artefact field (LocalArtefactId type should remain None)
+    artefact_id = odg.model.ComponentArtefactId(
+        component_name=None,
+        component_version=None,
+        artefact=None,  # This should stay None (not converted to string)
+        artefact_kind=None,  # This should stay None (not converted to string)
+        references=[],
+    )
+
+    result = odg.util._convert_none_to_empty_string_for_component_artefact_id(artefact_id)
+
+    assert result.component_name == ''  # String field: None -> ''
+    assert result.component_version == ''  # String field: None -> ''
+    assert result.artefact is None  # Non-string field: stays None
+    assert result.artefact_kind is None  # Enum field: stays None
+    assert result.references == []
+
+
+def test_convert_none_to_empty_string_artefact_kind_preserved():
+    # Test that artefact_kind None value is NOT converted to empty string
+    # This is critical because ArtefactKind is an enum, not a string
+    artefact_id = odg.model.ComponentArtefactId(
+        component_name='test-component',
+        component_version='1.0.0',
+        artefact_kind=None,  # Should remain None, not become ''
+        artefact=odg.model.LocalArtefactId(
+            artefact_name='test-artefact',
+        ),
+    )
+
+    result = odg.util._convert_none_to_empty_string_for_component_artefact_id(artefact_id)
+
+    # artefact_kind should remain None (enum type)
+    assert result.artefact_kind is None
+    # But string fields should be converted
+    assert result.component_name == 'test-component'
+    assert result.component_version == '1.0.0'


### PR DESCRIPTION
when fetching UUIDs

This is useful for license IP scanner extension, as the opt-out is required.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator
NONE
```
