### PR TITLE
feat(backlog-controller): Handle exception when deployment cannot be read

### DIFF
--- a/k8s/util.py
+++ b/k8s/util.py
@@ -125,10 +125,17 @@ def scale_replicas(
         name_parts=(service,),
         generate_num_suffix=False,
     )
-    deployment = kubernetes_api.apps_kubernetes_api.read_namespaced_deployment(
-        namespace=namespace,
-        name=name,
-    )
+
+    try:
+        deployment = kubernetes_api.apps_kubernetes_api.read_namespaced_deployment(
+            namespace=namespace,
+            name=name,
+        )
+    except kubernetes.client.rest.ApiException as e:
+        # do not let API exceptions block the general scaling (e.g. due to missing deployment)
+        logger.error(e)
+        return
+
     deployment: kubernetes.client.models.v1_deployment.V1Deployment
 
     current_replicas = deployment.spec.replicas


### PR DESCRIPTION
**What this PR does / why we need it**:
To prevent the backlog-controller to run into a error-loop when one deployment is missing, where no deployment at all is going to be scaled, ignore such errors (only log them as "error") and continue with the next operation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator
The backlog-controller will not fail (and block) anymore when a deployment is missing but only log an error and continue instead
```
