### PR TITLE
feat(odg-operator): Inject ODG id into Kubernetes manifests

### DIFF
--- a/k8s/model.py
+++ b/k8s/model.py
@@ -7,6 +7,10 @@ import kubernetes.client
 DOMAIN = 'delivery-gear.gardener.cloud'
 LABEL_SERVICE = f'{DOMAIN}/service'
 
+ODG_CLUSTER_REF_LABEL = 'open-delivery-gear.ocm.software/odg-cluster-ref'
+ODG_NAMESPACE_LABEL = 'open-delivery-gear.ocm.software/odg-namespace'
+ODG_NAME_LABEL = 'open-delivery-gear.ocm.software/odg-name'
+
 
 @dataclasses.dataclass(frozen=True)
 class Crd:

--- a/k8s/util.py
+++ b/k8s/util.py
@@ -95,6 +95,23 @@ def generate_kubernetes_name(
     return name
 
 
+def validated_label_value(value: str) -> str:
+    regex = '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'
+
+    if len(value) > 63:
+        raise ValueError(f'Invalid label {value=}: Must be no more than 63 bytes')
+
+    if not re.fullmatch(regex, value):
+        raise ValueError(
+            f'Invalid label {value=}: A valid label must be an empty string or consist of '
+            'alphanumeric characters, "-", "_" or ".", and must start and end with an alphanumeric '
+            'character (e.g. "MyValue", or "my_value", or "12345", regex used for validation is '
+            f'"{regex}"',
+        )
+
+    return value
+
+
 def normalise_pod_label(pod_label: str) -> str:
     pod_label = pod_label.title().replace('-', '').replace('_', '')
     return pod_label[:1].lower() + pod_label[1:]

--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -897,7 +897,8 @@ class OdgOperatorConfig(ExtensionCfgMixins):
     required_extension_names: list[str] = dataclasses.field(default_factory=list)
     extension_ocm_references: list[ExtensionDefinitionOcmReference] = dataclasses.field(
         default_factory=list,
-    )  # noqa: E501
+    )
+    cluster_identity: str = 'default-cluster-identity'
 
 
 @dataclasses.dataclass

--- a/odg_operator/__main__.py
+++ b/odg_operator/__main__.py
@@ -45,7 +45,6 @@ logger = logging.getLogger(__name__)
 
 ODG_CLEAN_UP_FINALISER = 'open-delivery-gear.ocm.software/odg-clean-up'
 ODG_RECONCILE_ANNOTATION = 'open-delivery-gear.ocm.software/reconcile'
-ODG_COMPONENT_NAME = 'ocm.software/ocm-gear'
 HELM_CHART_MEDIA_TYPE = 'application/vnd.cncf.helm.chart.content.v1.tar+gzip'
 ODG_EXTENSION_ARTEFACT_TYPE = 'odg-extension'
 DEFAULT_K8S_SECRET_MAX_BYTES = 1150000

--- a/odg_operator/__main__.py
+++ b/odg_operator/__main__.py
@@ -27,6 +27,7 @@ import ocm
 import ocm.iter
 
 import ctx_util
+import k8s.model
 import k8s.util
 import lookups
 import ocm_util
@@ -44,7 +45,6 @@ logger = logging.getLogger(__name__)
 
 ODG_CLEAN_UP_FINALISER = 'open-delivery-gear.ocm.software/odg-clean-up'
 ODG_RECONCILE_ANNOTATION = 'open-delivery-gear.ocm.software/reconcile'
-ODG_NAME_LABEL = 'open-delivery-gear.ocm.software/odg-name'
 ODG_COMPONENT_NAME = 'ocm.software/ocm-gear'
 HELM_CHART_MEDIA_TYPE = 'application/vnd.cncf.helm.chart.content.v1.tar+gzip'
 ODG_EXTENSION_ARTEFACT_TYPE = 'odg-extension'
@@ -252,7 +252,8 @@ def encode_and_split_manifests(
 def create_or_update_odg(
     odg: odgm.ODG,
     extension_definitions: list[odgm.ExtensionDefinition],
-    component_descriptor_lookup,
+    cluster_identity: str,
+    component_descriptor_lookup: ocm.ComponentDescriptorLookup,
     oci_client: oci.client.Client,
     kubernetes_api: k8s.util.KubernetesApi,
 ) -> tuple[
@@ -416,6 +417,13 @@ def create_or_update_odg(
                     f'{extension_artefact_name}-{idx}' for idx in range(len(encoded_manifests))
                 ]
 
+            labels_to_inject = {
+                # split into multiple labels to prevent value length limit of 63 chars
+                k8s.model.ODG_CLUSTER_REF_LABEL: k8s.util.validated_label_value(cluster_identity),
+                k8s.model.ODG_NAMESPACE_LABEL: k8s.util.validated_label_value(odg.namespace),
+                k8s.model.ODG_NAME_LABEL: k8s.util.validated_label_value(odg.name),
+            }
+
             data = {
                 'apiVersion': odgm.ManagedResourceMeta.apiVersion,
                 'kind': odgm.ManagedResourceMeta.kind,
@@ -423,12 +431,13 @@ def create_or_update_odg(
                     'name': extension_artefact_name,
                     'namespace': odg.namespace,
                     'labels': {
-                        ODG_NAME_LABEL: odg.name,  # we need to find them again
+                        k8s.model.ODG_NAME_LABEL: odg.name,  # we need to find them again
                     },
                 },
                 'spec': {
                     'class': odgm.ManagedResourceClasses.EXTERNAL,
                     'keepObjects': False,
+                    'injectLabels': labels_to_inject,
                     'secretRefs': [
                         {
                             'name': secret_name,
@@ -458,7 +467,7 @@ def create_or_update_odg(
                         name=secret_name,
                         namespace=odg.namespace,
                         labels={
-                            ODG_NAME_LABEL: odg.name,  # we need to find them again
+                            k8s.model.ODG_NAME_LABEL: odg.name,  # we need to find them again
                         },
                     ),
                     data={
@@ -563,7 +572,8 @@ def set_odg_state(
 def reconcile(
     extension_definitions: collections.abc.Iterable[odgm.ExtensionDefinition],
     required_extensions: list[str],
-    component_descriptor_lookup,
+    cluster_identity: str,
+    component_descriptor_lookup: ocm.ComponentDescriptorLookup,
     kubernetes_api: k8s.util.KubernetesApi,
     oci_client: oci.client.Client,
     group: str = odgm.ODGMeta.group,
@@ -650,7 +660,7 @@ def reconcile(
                     version=odgm.ManagedResourceMeta.version,
                     plural=odgm.ManagedResourceMeta.plural,
                     namespace=odg.namespace,
-                    label_selector=f'{ODG_NAME_LABEL}={odg.name}',
+                    label_selector=f'{k8s.model.ODG_NAME_LABEL}={odg.name}',
                 ).get('items', []):
                     delete_managed_resource(
                         kubernetes_api=kubernetes_api,
@@ -727,6 +737,7 @@ def reconcile(
                     status_for_extension, has_error = create_or_update_odg(
                         odg=odg,
                         extension_definitions=requested_extension_definitions,
+                        cluster_identity=cluster_identity,
                         component_descriptor_lookup=component_descriptor_lookup,
                         oci_client=oci_client,
                         kubernetes_api=kubernetes_api,
@@ -749,7 +760,7 @@ def reconcile(
                         version=odgm.ManagedResourceMeta.version,
                         plural=odgm.ManagedResourceMeta.plural,
                         namespace=odg.namespace,
-                        label_selector=f'{ODG_NAME_LABEL}={odg.name}',
+                        label_selector=f'{k8s.model.ODG_NAME_LABEL}={odg.name}',
                     ).get('items', []):
                         name = managed_resource['metadata']['name']
                         if name in desired_managed_resource_names:
@@ -982,6 +993,7 @@ if __name__ == '__main__':
         reconcile(
             extension_definitions=extension_definitions,
             required_extensions=odg_operator_cfg.required_extension_names,
+            cluster_identity=odg_operator_cfg.cluster_identity,
             component_descriptor_lookup=component_descriptor_lookup,
             oci_client=oci_client,
             kubernetes_api=kubernetes_api,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #791

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator
An ODG identity label is now injected by the Gardener Resource Manager into all Kubernetes manifests in the target cluster
```
