### PR TITLE
cfg(blackduck): Cleanup stale props and add new `deduplicate_across_component_versions` prop

### DIFF
--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -173,6 +173,10 @@ extensions_cfg:
             # - OPENSOURCE
             # - SAAS
             distribution_mode_overwrite: null
+        # @param extensions_cfg.blackduck.mappings[].deduplicate_across_component_versions if true,
+        # the BlackDuck scans of the same artefact version (+ extra-id) will be deduplicated across
+        # existing component versions
+        deduplicate_across_component_versions: true
         # @param extensions_cfg.blackduck.mappings[].aws_secret_name in case the resources are stored
         # in AWS S3 and multiple AWS secrets are specified via secrets.aws, the name of the aws
         # secret to use must be specified

--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -173,15 +173,6 @@ extensions_cfg:
             # - OPENSOURCE
             # - SAAS
             distribution_mode_overwrite: null
-        # @param extensions_cfg.blackduck.mappings[].group_id_bdba the BDBA group id to retrieve the
-        # scan results from
-        group_id_bdba: -1
-        # @param extensions_cfg.blackduck.mappings[].processing_mode the behaviour in case the BDBA
-        # scan already exists
-        # options:
-        # - rescan: re-use already uploaded binary and retrieve updated scan results
-        # - force_upload: always re-upload binary and retrieve updated scan results
-        processing_mode: rescan
         # @param extensions_cfg.blackduck.mappings[].aws_secret_name in case the resources are stored
         # in AWS S3 and multiple AWS secrets are specified via secrets.aws, the name of the aws
         # secret to use must be specified

--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -383,6 +383,7 @@ class BlackDuckTarget:
 class BlackDuckExtensionMapping(Mapping):
     targets: list[BlackDuckTarget]
     aws_secret_name: str | None
+    deduplicate_across_component_versions: bool = True
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -382,9 +382,7 @@ class BlackDuckTarget:
 @dataclasses.dataclass
 class BlackDuckExtensionMapping(Mapping):
     targets: list[BlackDuckTarget]
-    group_id_bdba: int
     aws_secret_name: str | None
-    processing_mode: str = 'rescan'
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/odg/extensions_cfg.yaml
+++ b/odg/extensions_cfg.yaml
@@ -24,7 +24,6 @@ blackduck:
   enabled: False
   mappings:
     - prefix: ''
-      group_id_bdba: 0 # <int> must be set
       targets:
         - group_id: '' # <str> must be set
           host: '' # <str> must be set


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```feature developer
Added new BlackDuck configuration option `deduplicate_across_component_versions` to re-use BlackDuck scans of the same artefact across component versions
```
```action developer
Removed obsolete options `group_id_bdba` and `processing_mode` from BlackDuck configuration since they are not used anymore by SBOM generation via Syft
```
