### PR TITLE
fix(issues): Prevent comparison between `str` and `NoneType` for sorting

### DIFF
--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -1409,12 +1409,12 @@ def template_issue_body(
     Also, artefacts which were not scanned yet are reported (if there are any).
     """
     artefact_sorting_key = lambda artefact: (  # noqa: E731
-        artefact.component_name,
-        artefact.component_version,
-        artefact.artefact_kind,
-        artefact.artefact.artefact_type,
-        artefact.artefact.artefact_name,
-        artefact.artefact.artefact_version,
+        artefact.component_name or '',
+        artefact.component_version or '',
+        artefact.artefact_kind or '',
+        artefact.artefact.artefact_type or '',
+        artefact.artefact.artefact_name or '',
+        artefact.artefact.artefact_version or '',
         artefact.artefact.normalised_artefact_extra_id,
     )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix operator
Prevent a bug in the issue-replicator where `str` items were compared to instances of `NoneType`
```
