### PR TITLE
feat(odg-client): Add custom retry logic to allow to always retry

### DIFF
--- a/odg_client/__init__.py
+++ b/odg_client/__init__.py
@@ -154,9 +154,7 @@ class DeliveryServiceClient:
         :param str api_url (optional)
             the (GitHub) API URL to use for authentication. Only considered if `auth_token` is set
         :param int max_retries (optional)
-            the maximum number of retries each connection should attempt. Note, this applies only to
-            failed DNS lookups, socket connections and connection timeouts, never to requests where
-            data has made it to the server
+            the maximum number of retries each request should attempt
         """
 
         if auth_token_lookup and auth_token:
@@ -170,6 +168,7 @@ class DeliveryServiceClient:
 
         self._bearer_token = None
         self._session = requests.sessions.Session()
+        self._max_retries = max_retries
         adapter = requests.adapters.HTTPAdapter(
             max_retries=max_retries,
         )
@@ -280,10 +279,27 @@ class DeliveryServiceClient:
         url: str,
         method: str = 'GET',
         headers: dict = None,
+        remaining_retries: int | None = None,
         **kwargs,
     ):
+        if remaining_retries is None:
+            remaining_retries = self._max_retries or 0
+
         try:
             self._authenticate()
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            if remaining_retries == 0:
+                raise
+
+            logger.warning(f'caught ConnectionError, going to retry... ({remaining_retries=}); {e}')
+
+            return self.request(
+                url=url,
+                method=method,
+                headers=headers,
+                remaining_retries=remaining_retries - 1,
+                **kwargs,
+            )
         except requests.exceptions.HTTPError as e:
             if e.response.status_code != 400:
                 raise
@@ -304,13 +320,28 @@ class DeliveryServiceClient:
         except KeyError:
             timeout = (4, 31)
 
-        res = self._session.request(
-            method=method,
-            url=url,
-            headers=headers,
-            timeout=timeout,
-            **kwargs,
-        )
+        try:
+            res = self._session.request(
+                method=method,
+                url=url,
+                headers=headers,
+                timeout=timeout,
+                **kwargs,
+            )
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            if remaining_retries == 0:
+                raise
+
+            logger.warning(f'caught ConnectionError, going to retry... ({remaining_retries=}); {e}')
+
+            return self.request(
+                url=url,
+                method=method,
+                headers=headers,
+                remaining_retries=remaining_retries - 1,
+                timeout=timeout,
+                **kwargs,
+            )
 
         return res
 
@@ -727,6 +758,7 @@ class DeliveryServiceClient:
             url=self._routes.blob(),
             method='POST',
             headers=headers,
+            remaining_retries=0,
             data=data,
         )
 

--- a/odg_client/__init__.py
+++ b/odg_client/__init__.py
@@ -311,8 +311,8 @@ class DeliveryServiceClient:
 
         if self._bearer_token:
             headers = {
-                'Authorization': f'Bearer {self._bearer_token}',
                 **headers,
+                'Authorization': f'Bearer {self._bearer_token}',
             }
 
         try:


### PR DESCRIPTION
**What this PR does / why we need it**:
With the standard retry mechanism provided via `urllib3`, requests are only retried in very specific use cases, e.g. not for `POST` requests (by default) and not in case data was already sent to the server.

Since the available `POST` methods of the `DeliveryServiceClient` (query metadata, create BLI, upload blob) can be retried with the very same payload without unintended side-effects, and also the general payloads are not exhaustable, we can always retry failed requests to try to solve ConnectionErrors or Timeouts.

**Which issue(s) this PR fixes**:
Fixes #804

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
Add custom retry logic to the DeliveryServiceClient to always retry (even on failed `POST` requests)
```
