### PR TITLE
fix(python-k8s): Pin `kubernetes` package version for now

### DIFF
--- a/requirements.utils.txt
+++ b/requirements.utils.txt
@@ -5,7 +5,7 @@ cachetools
 dacite
 gardener-cicd-libs==1.2756.0
 github3.py
-kubernetes
+kubernetes<36
 requests
 urllib3
 watchdog


### PR DESCRIPTION
**What this PR does / why we need it**:
`36.0.0` has known regression regarding in-cluster auth, see https://github.com/kubernetes-client/python/issues/2584

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator

```
