### PR TITLE
stability(sbom-generator): Increase memory pod limits

### DIFF
--- a/charts/extensions/charts/sbom-generator/templates/sbom-generator.yaml
+++ b/charts/extensions/charts/sbom-generator/templates/sbom-generator.yaml
@@ -81,7 +81,7 @@ spec:
               memory: 250Mi
               cpu: 250m
             limits:
-              memory: 500Mi
+              memory: 1200Mi
               cpu: 500m
       volumes:
         - name: aws


### PR DESCRIPTION
**What this PR does / why we need it**:
As syft holds the artefacts in memory to generate sbom documents, the memory capacity must be sufficient even for larger images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy operator
SBOM generator extension memory limits have been increased
```
