### PR TITLE
docs(kind): handle rootless Podman cgroup delegation on Linux and macOS

### DIFF
--- a/local-setup/local-setup.md
+++ b/local-setup/local-setup.md
@@ -42,6 +42,34 @@ create `<REPO_ROOT>/local-setup/kind/kubeconfig` which can be used to interact
 with the OCM-Gear cluster. Also, it will forward the delivery-service to
 `http://localhost:5000`.
 
+### Using Podman as container engine
+By default, `kind` uses Docker. To use [Podman](https://podman.io/) instead,
+set the `KIND_EXPERIMENTAL_PROVIDER` environment variable before running
+`make kind-up`:
+
+```bash
+export KIND_EXPERIMENTAL_PROVIDER=podman
+make kind-up
+```
+
+**Linux:** rootless Podman requires the kind process to run inside a systemd
+scope with cgroup delegation enabled. `kind-up.sh` handles this automatically
+by wrapping the cluster creation with
+`systemd-run --scope --user -p "Delegate=yes"` — no manual steps needed.
+
+**macOS:** Podman Desktop defaults to rootless mode inside its Linux VM, which
+can trigger the `Delegate=yes` error. The simplest fix is to switch the Podman
+machine to rootful mode:
+
+```bash
+podman machine stop
+podman machine set --rootful
+podman machine start
+```
+
+After that, `make kind-up` will complete successfully without any further
+configuration.
+
 ## Configuration Update
 To update the OCM-Gear deployment in case your local configuration has changed,
 just run the `make kind-update` command. This will upgrade the existing helm


### PR DESCRIPTION
**What this PR does / why we need it**:
On Linux, rootless Podman requires kind to run inside a systemd scope with `Delegate=yes` to manage cgroups. Wrap `kind create cluster` with `systemd-run --scope --user -p "Delegate=yes"` when `KIND_EXPERIMENTAL_PROVIDER=podman` and `systemd-run` is available.

On macOS, Podman Desktop runs rootless by default inside its Linux VM, which triggers the same error. Document the fix: switch the Podman machine to rootful mode via `podman machine set --rootful`.

Update local-setup.md with a dedicated "Using Podman as container engine" section covering both platforms.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Document updated

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator
category: documentation
target_group: operator|developer
```
