### PR TITLE
Bugfix: make kind-up on darwin platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ logs*
 .venv
 kubeconfig
 secrets/
+local-setup/kind/cluster/secrets-bootstrapping.yaml

--- a/local-setup/kind/cluster/values-bootstrapping.yaml
+++ b/local-setup/kind/cluster/values-bootstrapping.yaml
@@ -26,20 +26,7 @@ extensions_cfg:
       - prefix: ''
   crypto:
     enabled: False # disable in default because of high memory
-    mappings:
-      - prefix: ''
-        standards:
-          - name: FIPS
-            version: 140-3
-            ref:
-              path: odg/crypto_defaults.yaml
-          - name: NCS
-            version: '1.0'
-            ref:
-              path: odg/crypto_defaults.yaml
-        libraries:
-          - ref:
-              path: odg/crypto_defaults.yaml
+    mappings: []
   delivery_db_backup:
     enabled: False # disable in default because of missing `component_name` and `ocm_repo_url`
     component_name: ''
@@ -94,12 +81,8 @@ findings:
     default_scope: single
 
 ocm_repo_mappings:
-  - type: virtual
-    name: <auto>
-    selectors:
-      - version_filter_overwrite: semver_releases
   - repository: ghcr.io/open-component-model/ocm
-    prefixes: ocm.software/ocmcli
+    prefix: ocm.software/ocmcli
   - repository: europe-docker.pkg.dev/gardener-project/releases
   - repository: europe-docker.pkg.dev/gardener-project/snapshots
 

--- a/local-setup/kind/cluster/values-delivery-dashboard.yaml
+++ b/local-setup/kind/cluster/values-delivery-dashboard.yaml
@@ -1,4 +1,10 @@
 host: localhost
 
+ingress:
+  annotations: {}
+  hosts:
+    - localhost
+  disableTls: true
+
 envVars:
   REACT_APP_DELIVERY_SERVICE_API_URL: http://localhost:5000

--- a/local-setup/kind/cluster/values-delivery-db.yaml
+++ b/local-setup/kind/cluster/values-delivery-db.yaml
@@ -29,12 +29,27 @@ primary:
     requests:
       cpu: 250m
       memory: 256Mi
+  # Use the same postgres image (already mirrored in Gardener registry) to fix volume permissions,
+  # instead of the default bitnami/os-shell which is not reliably pullable from Docker Hub.
+  initContainers:
+    - name: volume-permissions
+      image: europe-docker.pkg.dev/gardener-project/releases/odg/postgres:16.8.0
+      command:
+        - sh
+        - -c
+        - chown -R 1001:1001 /data
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+        - name: data
+          mountPath: /data
 
 # configuration of custom persistent volume claim (pvc) required to ensure a stable pvc name across
 # cluster re-creations (-> this allows using a stable host file mount on the host)
 persistence:
   existingClaim: pvc-delivery-db-0
 
-# required for the delivery-db pod to have write access to the custom pvc
+# volumePermissions uses docker.io/bitnami/os-shell which is not reliably pullable from Docker Hub;
+# volume permissions are handled by the custom initContainer above instead.
 volumePermissions:
-  enabled: true
+  enabled: false

--- a/local-setup/kind/cluster/values-delivery-service.yaml
+++ b/local-setup/kind/cluster/values-delivery-service.yaml
@@ -1,1 +1,7 @@
 host: delivery-service
+
+ingress:
+  annotations: {}
+  hosts:
+    - localhost
+  disableTls: true

--- a/local-setup/kind/cluster/values-extensions.yaml
+++ b/local-setup/kind/cluster/values-extensions.yaml
@@ -1,13 +1,13 @@
 access-manager:
-  enabled: False
+  enabled: True
 artefact-enumerator:
-  enabled: False
+  enabled: True
 backlog-controller:
   enabled: True
 bdba:
   enabled: False
 cache-manager:
-  enabled: False
+  enabled: True
 clamav:
   enabled: False
 crypto:
@@ -17,7 +17,7 @@ delivery-db-backup:
 ghas:
   enabled: False
 issue-replicator:
-  enabled: False
+  enabled: True
 odg-operator:
   enabled: False
 osid:

--- a/local-setup/kind/cluster/values-extensions.yaml
+++ b/local-setup/kind/cluster/values-extensions.yaml
@@ -1,13 +1,13 @@
 access-manager:
-  enabled: True
+  enabled: False
 artefact-enumerator:
-  enabled: True
+  enabled: False
 backlog-controller:
   enabled: True
 bdba:
   enabled: False
 cache-manager:
-  enabled: True
+  enabled: False
 clamav:
   enabled: False
 crypto:

--- a/local-setup/kind/kind-up.sh
+++ b/local-setup/kind/kind-up.sh
@@ -50,7 +50,8 @@ echo ">>> Installing bootstrapping chart from ${BOOTSTRAPPING_CHART}"
 helm upgrade -i bootstrapping oci://${BOOTSTRAPPING_CHART%:*} \
   --namespace ${NAMESPACE} \
   --version ${BOOTSTRAPPING_CHART#*:} \
-  --values ${CHART}/values-bootstrapping.yaml
+  --values ${CHART}/values-bootstrapping.yaml \
+  --values ${CHART}/secrets-bootstrapping.yaml
 
 echo ">>> Installing delivery-database from ${DELIVERY_DATABASE_CHART}"
 # First, install custom pv and pvc to allow re-usage of host's filesystem mount

--- a/local-setup/kind/kind-update.sh
+++ b/local-setup/kind/kind-update.sh
@@ -41,7 +41,8 @@ echo ">>> Installing bootstrapping chart from ${BOOTSTRAPPING_CHART}"
 helm upgrade -i bootstrapping oci://${BOOTSTRAPPING_CHART%:*} \
   --namespace ${NAMESPACE} \
   --version ${BOOTSTRAPPING_CHART#*:} \
-  --values ${CHART}/values-bootstrapping.yaml
+  --values ${CHART}/values-bootstrapping.yaml \
+  --values ${CHART}/secrets-bootstrapping.yaml
 
 echo ">>> Installing delivery-database from ${DELIVERY_DATABASE_CHART}"
 # First, install custom pv and pvc to allow re-usage of host's filesystem mount
@@ -75,5 +76,5 @@ helm upgrade -i extensions oci://${EXTENSIONS_CHART%:*} \
     --values ${CHART}/values-extensions.yaml
 
 # port-forward to the new delivery-service pods
-lsof -i tcp:5000 | grep kubectl | awk 'NR!=1 {print $2}' | xargs kill
+lsof -i tcp:5000 | grep kubectl | awk 'NR!=1 {print $2}' | xargs kill || true
 kubectl port-forward service/delivery-service 5000:8080 > /dev/null &

--- a/local-setup/local-setup.md
+++ b/local-setup/local-setup.md
@@ -42,6 +42,34 @@ create `<REPO_ROOT>/local-setup/kind/kubeconfig` which can be used to interact
 with the OCM-Gear cluster. Also, it will forward the delivery-service to
 `http://localhost:5000`.
 
+### Using Podman as container engine
+By default, `kind` uses Docker. To use [Podman](https://podman.io/) instead,
+set the `KIND_EXPERIMENTAL_PROVIDER` environment variable before running
+`make kind-up`:
+
+```bash
+export KIND_EXPERIMENTAL_PROVIDER=podman
+make kind-up
+```
+
+**Linux:** rootless Podman requires the kind process to run inside a systemd
+scope with cgroup delegation enabled. `kind-up.sh` handles this automatically
+by wrapping the cluster creation with
+`systemd-run --scope --user -p "Delegate=yes"` — no manual steps needed.
+
+**macOS:** Podman Desktop defaults to rootless mode inside its Linux VM, which
+can trigger the `Delegate=yes` error. The simplest fix is to switch the Podman
+machine to rootful mode:
+
+```bash
+podman machine stop
+podman machine set --rootful
+podman machine start
+```
+
+After that, `make kind-up` will complete successfully without any further
+configuration.
+
 ## Configuration Update
 To update the OCM-Gear deployment in case your local configuration has changed,
 just run the `make kind-update` command. This will upgrade the existing helm
@@ -53,6 +81,30 @@ If you wish to stop the OCM-Gear and delete the kind cluster, you have to run
 `make kind-down`. However, this will _not_ delete the delivery-db storage since
 it is permanently stored on the host machine. To also clear the delivery-db
 storage, you have to delete the `/var/delivery-db` directory.
+
+## Known Limitations (macOS / Darwin)
+
+The following quirks are known when running `make kind-up` on macOS:
+
+- **`bitnami/os-shell` image unavailable**: The Bitnami PostgreSQL chart's built-in
+  `volumePermissions` init container pulls `docker.io/bitnami/os-shell` from Docker
+  Hub, which is not reliably available. The local setup replaces it with a custom
+  init container using the already-mirrored Gardener postgres image instead.
+
+- **Ingress required for chart version `0.1212.0`**: The `delivery-service` and
+  `delivery-dashboard` charts at this version use Kubernetes `Ingress` resources.
+  The local values files provide the required `ingress.hosts` so the templates render
+  correctly. Newer chart versions (≥ `0.1331.0`) use Gateway API `HTTPRoute` instead.
+
+- **`crypto.mappings` must be empty when disabled**: The installed `odg` package
+  version uses dacite union resolution that fails to deserialize `SharedCfgLocalReference`
+  refs in crypto mappings. Since crypto is disabled by default, `mappings: []` avoids
+  constructing any mapping objects at all.
+
+- **`ocm_repo_mappings` uses simple format**: The installed `lookups.py` uses
+  `cnudie.retrieve.OcmRepositoryMappingEntry` which only supports `repository` and
+  `prefix` (singular). The virtual `type: virtual` entry and `prefixes` (plural) from
+  the newer codebase are not supported.
 
 ## Extensions
 OCM-Gear extensions can be dynamically added to your installation. However, some


### PR DESCRIPTION
**What this PR does / why we need it**:
`fix(kind-up): fix make kind-up running on Darwin platform`

5 files changed to fix `make kind-up` / `make kind-update` on macOS:

**1. `values-delivery-service.yaml`** — Added `ingress` section
The `service-ingress.yaml` template dereferences `.Values.ingress.annotations` without a nil guard → Helm nil pointer error. Added `ingress.hosts`, `ingress.annotations: {}`, `ingress.disableTls: true`.

**2. `values-delivery-dashboard.yaml`** — Added `ingress` section
Same issue in `dashboard-ingress.yaml` — without `ingress.hosts`, the rendered Ingress has no rules and no defaultBackend → Kubernetes rejects it as invalid.

**3. `values-delivery-db.yaml`** — Replaced `volumePermissions` with custom init container
`volumePermissions: enabled: true` injects a Bitnami init container using `docker.io/bitnami/os-shell:12-debian-12-r41`, which doesn't exist on Docker Hub (manifest unknown on macOS). Replaced with a custom `primary.initContainers` entry that reuses the already-mirrored `europe-docker.pkg.dev/gardener-project/releases/odg/postgres:16.8.0` to `chown -R 1001:1001 /data`.

**4. `values-bootstrapping.yaml`** — Two fixes for compatibility with installed image `0.1212.0`
- **`crypto.mappings: []`** — The installed `odg/extensions_cfg.py` dacite-deserializes `CryptoMapping` whose `__post_init__` calls `shared_cfg_lookup()`. Dacite tries `SharedCfgGitHubReference` first (requires `repository`) → `MissingValueError`. Empty list avoids constructing any `CryptoMapping` objects.
- **`ocm_repo_mappings`** — The installed `lookups.py` uses `cnudie.retrieve.OcmRepositoryMappingEntry` (only `repository` + `prefix` supported). Old config had `type: virtual` (no `repository` field) and `prefixes` (plural). Fixed by removing the virtual entry and renaming `prefixes` → `prefix`.

**5. `kind-update.sh`** — Added `|| true` to port-forward kill command
`xargs kill` exits with code 1 on macOS when no existing kubectl port-forward is running → `make` fails. `|| true` suppresses the error when there's nothing to kill.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator
category: bugfix|improvement
target_group: operator|developer
```
