### PR TITLE
[hotfix-0.1334] [ci:component:github.com/gardener/cc-utils:1.2765.0->1.2766.0]

### DIFF
--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,7 +1,7 @@
 componentReferences:
 - componentName: github.com/gardener/cc-utils
   name: cc-utils
-  version: 1.2765.0
+  version: 1.2766.0
 - componentName: ocm.software/ocm-gear/bdba-client
   name: bdba
   version: 0.12.0

--- a/.ocm/release-notes/github.com_gardener_cc-utils_1.2766.0.release-notes.yaml
+++ b/.ocm/release-notes/github.com_gardener_cc-utils_1.2766.0.release-notes.yaml
@@ -1,0 +1,25 @@
+ocm:
+  component_name: github.com/gardener/cc-utils
+  component_version: 1.2766.0
+release_notes:
+- audience: developer
+  author:
+    hostname: github.com
+    type: githubUser
+    username: 8R0WNI3
+  category: bugfix
+  contents: Dropped usage of Delivery-Service client in CTT
+  mimetype: text/markdown
+  reference: '[#1578](https://github.com/gardener/cc-utils/pull/1578)'
+  type: standard
+- audience: developer
+  author:
+    hostname: github.com
+    type: githubUser
+    username: 8R0WNI3
+  category: bugfix
+  contents: Use (by now) required `BasicAuth` object instead of tuple in async OCI
+    client
+  mimetype: text/markdown
+  reference: '[#1602](https://github.com/gardener/cc-utils/pull/1602)'
+  type: standard

--- a/requirements.utils.txt
+++ b/requirements.utils.txt
@@ -3,7 +3,7 @@ bdba
 boto3
 cachetools
 dacite
-gardener-cicd-libs==1.2765.0
+gardener-cicd-libs==1.2766.0
 github3.py
 kubernetes<36
 requests


### PR DESCRIPTION
**Release Notes**:

# [github.com/gardener/cc-utils:1.2766.0]

## 🐛 Bug Fixes
- `[DEVELOPER]` Dropped usage of Delivery-Service client in CTT by @8R0WNI3 [[#1578](https://github.com/gardener/cc-utils/pull/1578)]
- `[DEVELOPER]` Use (by now) required `BasicAuth` object instead of tuple in async OCI client by @8R0WNI3 [[#1602](https://github.com/gardener/cc-utils/pull/1602)]

## BoM Diff
Added components: 0
Changed components: 1
Removed components: 0

### Changed Components:
⚙ github.com/gardener/cc-utils: 1.2765.0 → 1.2766.0

## Component Details:
<details><summary>⚙ github.com/gardener/cc-utils:1.2765.0 → 1.2766.0</summary>
<table>
<thead>
<tr><th>Resource               </th><th>Version Change     </th></tr>
</thead>
<tbody>
<tr><td>🔄 test-results         </td><td>1.2765.0 → 1.2766.0</td></tr>
<tr><td>🔄 gardener-cicd-libs   </td><td>1.2765.0 → 1.2766.0</td></tr>
<tr><td>🔄 gardener-gha-libs    </td><td>1.2765.0 → 1.2766.0</td></tr>
<tr><td>🔄 gardener-oci         </td><td>1.2765.0 → 1.2766.0</td></tr>
<tr><td>🔄 gardener-ocm         </td><td>1.2765.0 → 1.2766.0</td></tr>
<tr><td>🔄 sast-linting-evidence</td><td>1.2765.0 → 1.2766.0</td></tr>
<tr><td>🔄 release-notes        </td><td>1.2765.0 → 1.2766.0</td></tr>
<tr><td>🔄 release-notes-archive</td><td>1.2765.0 → 1.2766.0</td></tr>
<tr><td>🔄 branch-info          </td><td>1.2765.0 → 1.2766.0</td></tr>
</tbody>
</table>
</details>