### PR TITLE
ci: skip upgrade-dependencies workflow on fork repositories

### DIFF
--- a/.github/workflows/upgrade-dependencies.yaml
+++ b/.github/workflows/upgrade-dependencies.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   upgrade-pullrequests:
+    if: ${{ !github.event.repository.fork }}
     uses: gardener/cc-utils/.github/workflows/upgrade-dependencies.yaml@v1
     permissions:
       contents: read


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `if: !github.event.repository.fork` condition to the upgrade-pullrequests job to prevent it from running on forks.

Fork repos do not have the required OIDC trust configured for europe-docker.pkg.dev/gardener-project/releases, causing the workflow to fail with:

  Did not find matching OIDC cfg for
  image_reference=OciImageReference(europe-docker.pkg.dev/gardener-project/releases)



**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
ODG upgrade-dependency workflows no longer run on forked repositories
```
