### PR TITLE
fix(image): Link SAP certificates to Python's trust bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,6 @@ RUN --mount=type=bind,source=/dist,target=/dist \
     libc-dev \
     libffi-dev \
     python3-dev \
+&& ln -sf /etc/ssl/certs/ca-certificates.crt "$(python3 -m certifi)" \
 && mkdir /freshclam \
 && chown clamav /freshclam


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/94

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
The SAP CA certificates are now linked (again) to Python's trust bundle
```
