### PR TITLE
Revert "fix(image): Link SAP certificates to Python's trust bundle (#850)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,5 @@ RUN --mount=type=bind,source=/dist,target=/dist \
     libc-dev \
     libffi-dev \
     python3-dev \
-&& ln -sf /etc/ssl/certs/ca-certificates.crt "$(python3 -m certifi)" \
 && mkdir /freshclam \
 && chown clamav /freshclam


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit 0fbb4e081fdc64bd3f24a23705749899db7ea719.

The explicit link is not allowed here (would create a loop) because it is already implicitly done as part of `apk add py3-scipy`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator

```
