### PR TITLE
fix(backlog-controller): Optionally mount github secrets

### DIFF
--- a/charts/extensions/charts/backlog-controller/templates/backlog-controller.yaml
+++ b/charts/extensions/charts/backlog-controller/templates/backlog-controller.yaml
@@ -37,6 +37,10 @@ spec:
               mountPath: /secrets/kubernetes
             - name: extensions-cfg
               mountPath: /extensions_cfg
+            - name: github
+              mountPath: /secrets/github
+            - name: github-app
+              mountPath: /secrets/github-app
           resources:
             requests:
               memory: 100Mi
@@ -52,6 +56,14 @@ spec:
         - name: extensions-cfg
           configMap:
             name: extensions-cfg
+        - name: github
+          secret:
+            secretName: secret-factory-github
+            optional: true
+        - name: github-app
+          secret:
+            secretName: secret-factory-github-app
+            optional: true
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
shortterm fix for:
https://github.com/open-component-model/odg-core/issues/847

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix operator
Backlog Controller optionally mounts GitHub secrets now, to properly resolve extensions-cfg
```
