### PR TITLE
feat(ghas): Include more GitHub Secret Alert Location Information

### DIFF
--- a/ghas.py
+++ b/ghas.py
@@ -181,11 +181,17 @@ def get_secret_alerts(
     logger.info(f'found {count} secret alerts for {github_hostname}/{org}')
 
 
-def get_secret_location(
-    location_url: str,
+def iter_secret_locations(
+    location_url: str | None,
     secret_factory: secret_mgmt.SecretFactory,
-) -> odg.model.GitHubSecretFindingLocation:
+) -> collections.abc.Iterable[odg.model.GitHubSecretFindingLocation]:
     GitHubSecretLocationType = odg.model.GitHubSecretLocationType
+
+    if not location_url:
+        yield odg.model.GitHubSecretFindingLocation(
+            location_type=GitHubSecretLocationType.UNKNOWN,
+        )
+        return
 
     result, _ = github_api_request(
         url=location_url,
@@ -193,9 +199,10 @@ def get_secret_location(
     )
 
     if not result or not isinstance(result, list):
-        return odg.model.GitHubSecretFindingLocation(
+        yield odg.model.GitHubSecretFindingLocation(
             location_type=GitHubSecretLocationType.UNKNOWN,
         )
+        return
 
     for location in result:
         try:
@@ -204,15 +211,11 @@ def get_secret_location(
             location_type = GitHubSecretLocationType.UNKNOWN
 
         details = location.get('details', {})
-        return odg.model.GitHubSecretFindingLocation(
+        yield odg.model.GitHubSecretFindingLocation(
             location_type=location_type,
             path=details.get('path'),
             line=details.get('start_line'),
         )
-
-    return SecretLocation(
-        location_type=GitHubSecretLocationType.UNKNOWN,
-    )
 
 
 def as_artefact_metadata(
@@ -271,7 +274,7 @@ def create_ghas_findings(
                 )
 
                 for alert in alerts:
-                    location = get_secret_location(
+                    locations = iter_secret_locations(
                         location_url=alert.locations_url,
                         secret_factory=secret_factory,
                     )
@@ -290,9 +293,7 @@ def create_ghas_findings(
                         secret=alert.secret,
                         secret_type_display_name=alert.secret_type_display_name,
                         resolution=alert.resolution,
-                        path=location.path,
-                        line=location.line,
-                        location_type=location.location_type.value,
+                        locations=list(locations),
                         url=alert.url,
                     )
             except Exception as e:

--- a/ghas.py
+++ b/ghas.py
@@ -211,8 +211,26 @@ def iter_secret_locations(
             location_type = GitHubSecretLocationType.UNKNOWN
 
         details = location.get('details', {})
+
+        url = {
+            GitHubSecretLocationType.COMMIT: details.get('html_url'),
+            GitHubSecretLocationType.WIKI_COMMIT: details.get('commit_url'),
+            GitHubSecretLocationType.ISSUE_TITLE: details.get('html_url'),
+            GitHubSecretLocationType.ISSUE_BODY: details.get('html_url'),
+            GitHubSecretLocationType.ISSUE_COMMENT: details.get('html_url'),
+            GitHubSecretLocationType.DISCUSSION_TITLE: details.get('discussion_title_url'),
+            GitHubSecretLocationType.DISCUSSION_BODY: details.get('discussion_body_url'),
+            GitHubSecretLocationType.DISCUSSION_COMMENT: details.get('discussion_comment_url'),
+            GitHubSecretLocationType.PULL_REQUEST_TITLE: details.get('html_url'),
+            GitHubSecretLocationType.PULL_REQUEST_BODY: details.get('html_url'),
+            GitHubSecretLocationType.PULL_REQUEST_COMMENT: details.get('html_url'),
+            GitHubSecretLocationType.PULL_REQUEST_REVIEW: details.get('html_url'),
+            GitHubSecretLocationType.PULL_REQUEST_REVIEW_COMMENT: details.get('html_url'),
+        }.get(location_type)
+
         yield odg.model.GitHubSecretFindingLocation(
             location_type=location_type,
+            url=url,
             path=details.get('path'),
             line=details.get('start_line'),
         )

--- a/ghas.py
+++ b/ghas.py
@@ -4,7 +4,6 @@ import atexit
 import collections.abc
 import dataclasses
 import datetime
-import enum
 import functools
 import logging
 
@@ -35,33 +34,6 @@ import util
 logger = logging.getLogger(__name__)
 ci.log.configure_default_logging()
 k8s.logging.configure_kubernetes_logging()
-
-
-class GitHubSecretLocationType(enum.StrEnum):
-    COMMIT = 'commit'
-    WIKI_COMMIT = 'wiki_commit'
-    UNKNOWN = 'unknown'
-
-
-@dataclasses.dataclass
-class SecretLocation:
-    location_type: GitHubSecretLocationType
-    path: str | None = None
-    line: int | None = None
-
-    @classmethod
-    def from_dict(cls, location: dict) -> 'SecretLocation':
-        try:
-            location_type = GitHubSecretLocationType(location.get('type'))
-        except ValueError:
-            location_type = GitHubSecretLocationType.UNKNOWN
-
-        details = location.get('details', {})
-        return cls(
-            location_type=location_type,
-            path=details.get('path'),
-            line=details.get('start_line'),
-        )
 
 
 @dataclasses.dataclass
@@ -212,23 +184,31 @@ def get_secret_alerts(
 def get_secret_location(
     location_url: str,
     secret_factory: secret_mgmt.SecretFactory,
-) -> SecretLocation:
+) -> odg.model.GitHubSecretFindingLocation:
+    GitHubSecretLocationType = odg.model.GitHubSecretLocationType
+
     result, _ = github_api_request(
         url=location_url,
         secret_factory=secret_factory,
     )
+
     if not result or not isinstance(result, list):
-        return SecretLocation(
+        return odg.model.GitHubSecretFindingLocation(
             location_type=GitHubSecretLocationType.UNKNOWN,
         )
 
-    for loc in result:
-        secret_location = SecretLocation.from_dict(loc)
-        if secret_location.location_type in (
-            GitHubSecretLocationType.COMMIT,
-            GitHubSecretLocationType.WIKI_COMMIT,
-        ):
-            return secret_location
+    for location in result:
+        try:
+            location_type = GitHubSecretLocationType(location.get('type'))
+        except ValueError:
+            location_type = GitHubSecretLocationType.UNKNOWN
+
+        details = location.get('details', {})
+        return odg.model.GitHubSecretFindingLocation(
+            location_type=location_type,
+            path=details.get('path'),
+            line=details.get('start_line'),
+        )
 
     return SecretLocation(
         location_type=GitHubSecretLocationType.UNKNOWN,

--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -713,13 +713,25 @@ def ghas_summary(
     delivery_dashboard_url: str | None = None,
     sprint: sm.Sprint | None = None,
 ) -> tuple[str, str, str]:
+    def _locations_str(
+        locations: list[odg.model.GitHubSecretFindingLocation] | None,
+    ) -> str:
+        if locations is None:
+            return ''
+
+        return '<br>'.join(
+            f'[{location.location_type}]({location.url})'
+            if location.url
+            else str(location.location_type)
+            for location in locations
+        )
+
     finding_table_callback = {
         'Secret Type': lambda f, _: f'`{f.finding.data.secret_type}`',
         'Secret': lambda f, _: f'`{_redact_secret(f.finding.data.secret)}`',
-        'Path': lambda f, _: f'`{f.finding.data.path}`' if f.finding.data.path else '',
-        'Line': lambda f, _: f'`{f.finding.data.line}`' if f.finding.data.line else '',
         'Display Name': lambda f, _: f'`{f.finding.data.secret_type_display_name}`',
-        'Ref': lambda f, _: f'[ref]({f.finding.data.html_url})',
+        'Location(s)': lambda f, g: _locations_str(f.finding.data.locations),
+        'Alert Details': lambda f, _: f'[Alert]({f.finding.data.html_url})',
         'Severity': lambda f, g: _severity_str(
             aggregated_finding=f,
             finding_group=g,

--- a/odg/model.py
+++ b/odg/model.py
@@ -633,6 +633,19 @@ class RescoreOsIdFinding:
         return _as_key(self.osid.ID)
 
 
+class GitHubSecretLocationType(enum.StrEnum):
+    COMMIT = 'commit'
+    WIKI_COMMIT = 'wiki_commit'
+    UNKNOWN = 'unknown'
+
+
+@dataclasses.dataclass
+class GitHubSecretFindingLocation:
+    location_type: GitHubSecretLocationType
+    path: str | None = None
+    line: int | None = None
+
+
 @dataclasses.dataclass
 class GitHubSecretFinding(Finding):
     html_url: str

--- a/odg/model.py
+++ b/odg/model.py
@@ -653,6 +653,7 @@ class GitHubSecretLocationType(enum.StrEnum):
 @dataclasses.dataclass
 class GitHubSecretFindingLocation:
     location_type: GitHubSecretLocationType
+    url: str | None = None
     path: str | None = None
     line: int | None = None
 

--- a/odg/model.py
+++ b/odg/model.py
@@ -636,6 +636,17 @@ class RescoreOsIdFinding:
 class GitHubSecretLocationType(enum.StrEnum):
     COMMIT = 'commit'
     WIKI_COMMIT = 'wiki_commit'
+    ISSUE_TITLE = 'issue_title'
+    ISSUE_BODY = 'issue_body'
+    ISSUE_COMMENT = 'issue_comment'
+    DISCUSSION_TITLE = 'discussion_title'
+    DISCUSSION_BODY = 'discussion_body'
+    DISCUSSION_COMMENT = 'discussion_comment'
+    PULL_REQUEST_TITLE = 'pull_request_title'
+    PULL_REQUEST_BODY = 'pull_request_body'
+    PULL_REQUEST_COMMENT = 'pull_request_comment'
+    PULL_REQUEST_REVIEW = 'pull_request_review'
+    PULL_REQUEST_REVIEW_COMMENT = 'pull_request_review_comment'
     UNKNOWN = 'unknown'
 
 
@@ -653,10 +664,11 @@ class GitHubSecretFinding(Finding):
     secret_type: str
     secret_type_display_name: str
     resolution: str | None
-    path: str | None
-    line: int | None
-    location_type: str
     url: str
+    locations: list[GitHubSecretFindingLocation] | None
+    path: str | None = None  # has been replaced by `locations` -> keep for backwards compatibility
+    line: int | None = None  # has been replaced by `locations`
+    location_type: str | None = None  # has been replaced by `locations`
 
     @property
     def key(self) -> str:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/116

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```feature user
The GitHub Secret Scanning alerts now include more information on the location, especially the location URL
```
