### PR TITLE
feat(sprints): Allow configuration of a sprint date which is used as due date

### DIFF
--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -579,12 +579,6 @@ extensions_cfg:
               date_string_format: "%Y-%m-%d"
             # @param extensions_cfg.issue_replicator.mappings[].milestones.title.suffix
             suffix: null
-          # @param extensions_cfg.issue_replicator.mappings[].milestones.due_date contains
-          # configuration options to specify how the GitHub milestone due-date is determined
-          due_date:
-            # @param extensions_cfg.issue_replicator.mappings[].milestones.due_date.date_name the
-            # name of the date as specified in the sprints configuration
-            date_name: end_date
 
   # @param extensions_cfg.osid workers which identify base image OS versions for OCI images
   osid:

--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -861,6 +861,9 @@ sprints:
         # @param sprints.meta.offsets[].offset_days the offsets are relative to
         # sprints.sprints[].end_date
         offset_days: -1
+    # @param sprints.meta.finding_due_date_offset_name the name of the date which should be used as
+    # general due date within ODG (e.g. for GitHub milestone due dates, display in ODG UI, ...)
+    finding_due_date_offset_name: end_date
 
   sprints:
       # @param sprints.sprints[].name human-readable sprint name, must be unique within the list
@@ -1132,6 +1135,10 @@ features_cfg:
           # @param features_cfg.sprints.meta.offsets[].offset_days the offsets are relative to the
           # end date of the sprint
           offset_days: -1
+      # @param features_cfg.sprints.meta.finding_due_date_offset_name the name of the date which
+      # should be used as general due date within ODG (e.g. for GitHub milestone due dates, display
+      # in ODG UI, ...)
+      finding_due_date_offset_name: end_date
     # @param features_cfg.sprints.repoUrl GitHub html url of the repository where the sprints are
     # configured
     # e.g.
@@ -1144,6 +1151,7 @@ features_cfg:
     #     - name: release_decision
     #       display_name: Release Decision
     #       offset_days: -1
+    #   finding_due_date_offset_name: end_date
     # sprints:
     #   - name: <sprint-name>
     #     end_date: "<YYYY-MM-DD>"

--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -987,17 +987,10 @@ class IssueReplicatorMapping(Mapping):
             else:
                 title_callback = sm.MilestoneConfiguration.title_callback
 
-            if milestone_due_date_cfg := self.milestones.get('due_date'):
-                name = milestone_due_date_cfg['date_name']
-                due_date_callback = lambda sprint: sprint.find_sprint_date(name).value  # noqa: E731
-            else:
-                due_date_callback = sm.MilestoneConfiguration.due_date_callback
-
             self.milestones = sm.MilestoneConfiguration(
                 title_callback=title_callback,
                 title_prefix=title_prefix,
                 title_suffix=title_suffix,
-                due_date_callback=due_date_callback,
             )
 
 

--- a/sprints/github.py
+++ b/sprints/github.py
@@ -100,7 +100,7 @@ def iter_and_create_github_milestones(
             logger.debug(f'GitHub milestone {title} is already existing - skipping creation')
 
         else:
-            due_date = milestone_cfg.due_date_callback(sprint)
+            due_date = sprint.due_date
             due_on = datetime.datetime(
                 year=due_date.year,
                 month=due_date.month,

--- a/sprints/model.py
+++ b/sprints/model.py
@@ -18,6 +18,7 @@ class SprintOffsets:
 @dataclasses.dataclass
 class SprintMetadata:
     offsets: list[SprintOffsets] = dataclasses.field(default_factory=list)
+    finding_due_date_offset_name: str = SprintNames.END_DATE
 
 
 @dataclasses.dataclass
@@ -31,6 +32,7 @@ class SprintDate:
 class Sprint:
     name: str
     dates: list[SprintDate]
+    finding_due_date_offset_name: str = SprintNames.END_DATE
 
     def __post_init__(self):
         seen_names = set()
@@ -39,6 +41,9 @@ class Sprint:
             if sprint_date.name in seen_names:
                 raise ValueError(f'Found duplicate date with name {sprint_date.name} in {self}')
             seen_names.add(sprint_date.name)
+
+        if self.finding_due_date_offset_name not in seen_names:
+            raise ValueError(f'Did not find date for {self.finding_due_date_offset_name=} in {self}')
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, type(self)):
@@ -50,7 +55,7 @@ class Sprint:
 
     @property
     def due_date(self) -> datetime.date:
-        return self.find_sprint_date(SprintNames.END_DATE).value
+        return self.find_sprint_date(self.finding_due_date_offset_name).value
 
     def find_sprint_date(
         self,
@@ -73,7 +78,12 @@ class SprintsConfiguration:
     sprints: list[Sprint | dict]
 
     def __post_init__(self):
-        offsets = self.meta.offsets if self.meta else []
+        if self.meta:
+            offsets = self.meta.offsets
+            finding_due_date_offset_name = self.meta.finding_due_date_offset_name
+        else:
+            offsets = []
+            finding_due_date_offset_name = SprintNames.END_DATE
 
         sprints = []
         for sprint in self.sprints:
@@ -106,6 +116,7 @@ class SprintsConfiguration:
                 Sprint(
                     name=sprint['name'],
                     dates=sprint_dates,
+                    finding_due_date_offset_name=finding_due_date_offset_name,
                 ),
             )
 

--- a/sprints/model.py
+++ b/sprints/model.py
@@ -128,6 +128,3 @@ class MilestoneConfiguration:
     title_callback: collections.abc.Callable[[Sprint], str] = lambda sprint: sprint.name
     title_prefix: str | None = 'sprint-'
     title_suffix: str | None = None
-    due_date_callback: collections.abc.Callable[[Sprint], datetime.date] = lambda sprint: (
-        sprint.due_date
-    )


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```feature operator
The sprints configuration now allows to configure a "finding_due_date_offset_name" which is used as due date of the sprint (e.g. for display in the ODG UI or for the to-be created GitHub milestones)
```
```breaking operator
Removed the option to configure the due date for the GitHub milestones in favour of the configuration of the due date for sprints in general
```
