### PR TITLE
[hotfix-0.1334] Fix GitHub Milestone Due Dates and Include GitHub Secret Alert Location

### DIFF
--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -570,12 +570,6 @@ extensions_cfg:
               date_string_format: "%Y-%m-%d"
             # @param extensions_cfg.issue_replicator.mappings[].milestones.title.suffix
             suffix: null
-          # @param extensions_cfg.issue_replicator.mappings[].milestones.due_date contains
-          # configuration options to specify how the GitHub milestone due-date is determined
-          due_date:
-            # @param extensions_cfg.issue_replicator.mappings[].milestones.due_date.date_name the
-            # name of the date as specified in the sprints configuration
-            date_name: end_date
 
   # @param extensions_cfg.osid workers which identify base image OS versions for OCI images
   osid:
@@ -852,6 +846,9 @@ sprints:
         # @param sprints.meta.offsets[].offset_days the offsets are relative to
         # sprints.sprints[].end_date
         offset_days: -1
+    # @param sprints.meta.finding_due_date_offset_name the name of the date which should be used as
+    # general due date within ODG (e.g. for GitHub milestone due dates, display in ODG UI, ...)
+    finding_due_date_offset_name: end_date
 
   sprints:
       # @param sprints.sprints[].name human-readable sprint name, must be unique within the list
@@ -1123,6 +1120,10 @@ features_cfg:
           # @param features_cfg.sprints.meta.offsets[].offset_days the offsets are relative to the
           # end date of the sprint
           offset_days: -1
+      # @param features_cfg.sprints.meta.finding_due_date_offset_name the name of the date which
+      # should be used as general due date within ODG (e.g. for GitHub milestone due dates, display
+      # in ODG UI, ...)
+      finding_due_date_offset_name: end_date
     # @param features_cfg.sprints.repoUrl GitHub html url of the repository where the sprints are
     # configured
     # e.g.
@@ -1135,6 +1136,7 @@ features_cfg:
     #     - name: release_decision
     #       display_name: Release Decision
     #       offset_days: -1
+    #   finding_due_date_offset_name: end_date
     # sprints:
     #   - name: <sprint-name>
     #     end_date: "<YYYY-MM-DD>"

--- a/ghas.py
+++ b/ghas.py
@@ -4,7 +4,6 @@ import atexit
 import collections.abc
 import dataclasses
 import datetime
-import enum
 import functools
 import logging
 
@@ -35,33 +34,6 @@ import util
 logger = logging.getLogger(__name__)
 ci.log.configure_default_logging()
 k8s.logging.configure_kubernetes_logging()
-
-
-class GitHubSecretLocationType(enum.StrEnum):
-    COMMIT = 'commit'
-    WIKI_COMMIT = 'wiki_commit'
-    UNKNOWN = 'unknown'
-
-
-@dataclasses.dataclass
-class SecretLocation:
-    location_type: GitHubSecretLocationType
-    path: str | None = None
-    line: int | None = None
-
-    @classmethod
-    def from_dict(cls, location: dict) -> 'SecretLocation':
-        try:
-            location_type = GitHubSecretLocationType(location.get('type'))
-        except ValueError:
-            location_type = GitHubSecretLocationType.UNKNOWN
-
-        details = location.get('details', {})
-        return cls(
-            location_type=location_type,
-            path=details.get('path'),
-            line=details.get('start_line'),
-        )
 
 
 @dataclasses.dataclass
@@ -209,30 +181,59 @@ def get_secret_alerts(
     logger.info(f'found {count} secret alerts for {github_hostname}/{org}')
 
 
-def get_secret_location(
-    location_url: str,
+def iter_secret_locations(
+    location_url: str | None,
     secret_factory: secret_mgmt.SecretFactory,
-) -> SecretLocation:
+) -> collections.abc.Iterable[odg.model.GitHubSecretFindingLocation]:
+    GitHubSecretLocationType = odg.model.GitHubSecretLocationType
+
+    if not location_url:
+        yield odg.model.GitHubSecretFindingLocation(
+            location_type=GitHubSecretLocationType.UNKNOWN,
+        )
+        return
+
     result, _ = github_api_request(
         url=location_url,
         secret_factory=secret_factory,
     )
+
     if not result or not isinstance(result, list):
-        return SecretLocation(
+        yield odg.model.GitHubSecretFindingLocation(
             location_type=GitHubSecretLocationType.UNKNOWN,
         )
+        return
 
-    for loc in result:
-        secret_location = SecretLocation.from_dict(loc)
-        if secret_location.location_type in (
-            GitHubSecretLocationType.COMMIT,
-            GitHubSecretLocationType.WIKI_COMMIT,
-        ):
-            return secret_location
+    for location in result:
+        try:
+            location_type = GitHubSecretLocationType(location.get('type'))
+        except ValueError:
+            location_type = GitHubSecretLocationType.UNKNOWN
 
-    return SecretLocation(
-        location_type=GitHubSecretLocationType.UNKNOWN,
-    )
+        details = location.get('details', {})
+
+        url = {
+            GitHubSecretLocationType.COMMIT: details.get('html_url'),
+            GitHubSecretLocationType.WIKI_COMMIT: details.get('commit_url'),
+            GitHubSecretLocationType.ISSUE_TITLE: details.get('html_url'),
+            GitHubSecretLocationType.ISSUE_BODY: details.get('html_url'),
+            GitHubSecretLocationType.ISSUE_COMMENT: details.get('html_url'),
+            GitHubSecretLocationType.DISCUSSION_TITLE: details.get('discussion_title_url'),
+            GitHubSecretLocationType.DISCUSSION_BODY: details.get('discussion_body_url'),
+            GitHubSecretLocationType.DISCUSSION_COMMENT: details.get('discussion_comment_url'),
+            GitHubSecretLocationType.PULL_REQUEST_TITLE: details.get('html_url'),
+            GitHubSecretLocationType.PULL_REQUEST_BODY: details.get('html_url'),
+            GitHubSecretLocationType.PULL_REQUEST_COMMENT: details.get('html_url'),
+            GitHubSecretLocationType.PULL_REQUEST_REVIEW: details.get('html_url'),
+            GitHubSecretLocationType.PULL_REQUEST_REVIEW_COMMENT: details.get('html_url'),
+        }.get(location_type)
+
+        yield odg.model.GitHubSecretFindingLocation(
+            location_type=location_type,
+            url=url,
+            path=details.get('path'),
+            line=details.get('start_line'),
+        )
 
 
 def as_artefact_metadata(
@@ -291,7 +292,7 @@ def create_ghas_findings(
                 )
 
                 for alert in alerts:
-                    location = get_secret_location(
+                    locations = iter_secret_locations(
                         location_url=alert.locations_url,
                         secret_factory=secret_factory,
                     )
@@ -310,9 +311,7 @@ def create_ghas_findings(
                         secret=alert.secret,
                         secret_type_display_name=alert.secret_type_display_name,
                         resolution=alert.resolution,
-                        path=location.path,
-                        line=location.line,
-                        location_type=location.location_type.value,
+                        locations=list(locations),
                         url=alert.url,
                     )
             except Exception as e:

--- a/issue_replicator/github.py
+++ b/issue_replicator/github.py
@@ -713,13 +713,25 @@ def ghas_summary(
     delivery_dashboard_url: str | None = None,
     sprint: sm.Sprint | None = None,
 ) -> tuple[str, str, str]:
+    def _locations_str(
+        locations: list[odg.model.GitHubSecretFindingLocation] | None,
+    ) -> str:
+        if locations is None:
+            return ''
+
+        return '<br>'.join(
+            f'[{location.location_type}]({location.url})'
+            if location.url
+            else str(location.location_type)
+            for location in locations
+        )
+
     finding_table_callback = {
         'Secret Type': lambda f, _: f'`{f.finding.data.secret_type}`',
         'Secret': lambda f, _: f'`{_redact_secret(f.finding.data.secret)}`',
-        'Path': lambda f, _: f'`{f.finding.data.path}`' if f.finding.data.path else '',
-        'Line': lambda f, _: f'`{f.finding.data.line}`' if f.finding.data.line else '',
         'Display Name': lambda f, _: f'`{f.finding.data.secret_type_display_name}`',
-        'Ref': lambda f, _: f'[ref]({f.finding.data.html_url})',
+        'Location(s)': lambda f, g: _locations_str(f.finding.data.locations),
+        'Alert Details': lambda f, _: f'[Alert]({f.finding.data.html_url})',
         'Severity': lambda f, g: _severity_str(
             aggregated_finding=f,
             finding_group=g,

--- a/odg/extensions_cfg.py
+++ b/odg/extensions_cfg.py
@@ -980,17 +980,10 @@ class IssueReplicatorMapping(Mapping):
             else:
                 title_callback = sm.MilestoneConfiguration.title_callback
 
-            if milestone_due_date_cfg := self.milestones.get('due_date'):
-                name = milestone_due_date_cfg['date_name']
-                due_date_callback = lambda sprint: sprint.find_sprint_date(name).value  # noqa: E731
-            else:
-                due_date_callback = sm.MilestoneConfiguration.due_date_callback
-
             self.milestones = sm.MilestoneConfiguration(
                 title_callback=title_callback,
                 title_prefix=title_prefix,
                 title_suffix=title_suffix,
-                due_date_callback=due_date_callback,
             )
 
 

--- a/odg/model.py
+++ b/odg/model.py
@@ -613,6 +613,31 @@ class RescoreOsIdFinding:
         return _as_key(self.osid.ID)
 
 
+class GitHubSecretLocationType(enum.StrEnum):
+    COMMIT = 'commit'
+    WIKI_COMMIT = 'wiki_commit'
+    ISSUE_TITLE = 'issue_title'
+    ISSUE_BODY = 'issue_body'
+    ISSUE_COMMENT = 'issue_comment'
+    DISCUSSION_TITLE = 'discussion_title'
+    DISCUSSION_BODY = 'discussion_body'
+    DISCUSSION_COMMENT = 'discussion_comment'
+    PULL_REQUEST_TITLE = 'pull_request_title'
+    PULL_REQUEST_BODY = 'pull_request_body'
+    PULL_REQUEST_COMMENT = 'pull_request_comment'
+    PULL_REQUEST_REVIEW = 'pull_request_review'
+    PULL_REQUEST_REVIEW_COMMENT = 'pull_request_review_comment'
+    UNKNOWN = 'unknown'
+
+
+@dataclasses.dataclass
+class GitHubSecretFindingLocation:
+    location_type: GitHubSecretLocationType
+    url: str | None = None
+    path: str | None = None
+    line: int | None = None
+
+
 @dataclasses.dataclass
 class GitHubSecretFinding(Finding):
     html_url: str
@@ -620,10 +645,11 @@ class GitHubSecretFinding(Finding):
     secret_type: str
     secret_type_display_name: str
     resolution: str | None
-    path: str | None
-    line: int | None
-    location_type: str
     url: str
+    locations: list[GitHubSecretFindingLocation] | None
+    path: str | None = None  # has been replaced by `locations` -> keep for backwards compatibility
+    line: int | None = None  # has been replaced by `locations`
+    location_type: str | None = None  # has been replaced by `locations`
 
     @property
     def key(self) -> str:

--- a/sprints/github.py
+++ b/sprints/github.py
@@ -100,7 +100,7 @@ def iter_and_create_github_milestones(
             logger.debug(f'GitHub milestone {title} is already existing - skipping creation')
 
         else:
-            due_date = milestone_cfg.due_date_callback(sprint)
+            due_date = sprint.due_date
             due_on = datetime.datetime(
                 year=due_date.year,
                 month=due_date.month,

--- a/sprints/model.py
+++ b/sprints/model.py
@@ -18,6 +18,7 @@ class SprintOffsets:
 @dataclasses.dataclass
 class SprintMetadata:
     offsets: list[SprintOffsets] = dataclasses.field(default_factory=list)
+    finding_due_date_offset_name: str = SprintNames.END_DATE
 
 
 @dataclasses.dataclass
@@ -31,6 +32,7 @@ class SprintDate:
 class Sprint:
     name: str
     dates: list[SprintDate]
+    finding_due_date_offset_name: str = SprintNames.END_DATE
 
     def __post_init__(self):
         seen_names = set()
@@ -39,6 +41,9 @@ class Sprint:
             if sprint_date.name in seen_names:
                 raise ValueError(f'Found duplicate date with name {sprint_date.name} in {self}')
             seen_names.add(sprint_date.name)
+
+        if self.finding_due_date_offset_name not in seen_names:
+            raise ValueError(f'Did not find date for {self.finding_due_date_offset_name=} in {self}')
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, type(self)):
@@ -50,7 +55,7 @@ class Sprint:
 
     @property
     def due_date(self) -> datetime.date:
-        return self.find_sprint_date(SprintNames.END_DATE).value
+        return self.find_sprint_date(self.finding_due_date_offset_name).value
 
     def find_sprint_date(
         self,
@@ -73,7 +78,12 @@ class SprintsConfiguration:
     sprints: list[Sprint | dict]
 
     def __post_init__(self):
-        offsets = self.meta.offsets if self.meta else []
+        if self.meta:
+            offsets = self.meta.offsets
+            finding_due_date_offset_name = self.meta.finding_due_date_offset_name
+        else:
+            offsets = []
+            finding_due_date_offset_name = SprintNames.END_DATE
 
         sprints = []
         for sprint in self.sprints:
@@ -106,6 +116,7 @@ class SprintsConfiguration:
                 Sprint(
                     name=sprint['name'],
                     dates=sprint_dates,
+                    finding_due_date_offset_name=finding_due_date_offset_name,
                 ),
             )
 
@@ -117,6 +128,3 @@ class MilestoneConfiguration:
     title_callback: collections.abc.Callable[[Sprint], str] = lambda sprint: sprint.name
     title_prefix: str | None = 'sprint-'
     title_suffix: str | None = None
-    due_date_callback: collections.abc.Callable[[Sprint], datetime.date] = lambda sprint: (
-        sprint.due_date
-    )


### PR DESCRIPTION
**What this PR does / why we need it**:
Includes:
- https://github.com/open-component-model/odg-core/pull/853
- https://github.com/open-component-model/odg-core/pull/854

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```feature operator
The sprints configuration now allows to configure a "finding_due_date_offset_name" which is used as due date of the sprint (e.g. for display in the ODG UI or for the to-be created GitHub milestones)
```
```breaking operator
Removed the option to configure the due date for the GitHub milestones in favour of the configuration of the due date for sprints in general
```
```feature user
The GitHub Secret Scanning alerts now include more information on the location, especially the location URL
```
