### PR TITLE
fix(rescoring): Do not overshadow user rescorings

### DIFF
--- a/src/bdba_utils/util.py
+++ b/src/bdba_utils/util.py
@@ -51,6 +51,7 @@ def iter_artefact_metadata(
     delivery_service_client: odg_client.DeliveryServiceClient,
     vulnerability_cfg: odg.findings.Finding | None = None,
     license_cfg: odg.findings.Finding | None = None,
+    create_rescorings_for_upstream_re_ratings: bool = False,
 ) -> collections.abc.Generator[odg.model.ArtefactMetadata, None, None]:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     discovery_date = datetime.date.today()
@@ -251,7 +252,8 @@ def iter_artefact_metadata(
                 yield artefact_metadata
 
                 if (
-                    (existing_finding := existing_findings_by_key.get(artefact_metadata.key))
+                    create_rescorings_for_upstream_re_ratings
+                    and (existing_finding := existing_findings_by_key.get(artefact_metadata.key))
                     and existing_finding.data.cvss_v3_score != artefact_metadata.data.cvss_v3_score
                     and existing_finding.data.severity != artefact_metadata.data.severity
                     and existing_finding.allowed_processing_time


### PR DESCRIPTION
Upstream CVE re-ratings will still be reflected in ODG, however the traceability via rescorings is shortcut for the moment.

Rational:
In the current implementation the rescoring specificity is also honoured when applying rescorings. As upstream changes result in rescorings of scope `single`, they always win over default rescoring scope `artefact`.

There are couple of options to address this, please see: https://github.com/open-component-model/open-delivery-gear/issues/106

For the moment the safest option is to shortcut automatic rescoring creation.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix user
Upstream CVE re-ratings no longer overshadow user rescorings of scope `artefact`, `component`, and `global`
```
