### PR TITLE
fix(sbom-generator): Make `secret-factory-bdba` secret optional

### DIFF
--- a/charts/extensions/charts/sbom-generator/templates/sbom-generator.yaml
+++ b/charts/extensions/charts/sbom-generator/templates/sbom-generator.yaml
@@ -91,6 +91,7 @@ spec:
         - name: bdba
           secret:
             secretName: secret-factory-bdba
+            optional: true
         - name: github
           secret:
             secretName: secret-factory-github


### PR DESCRIPTION
**What this PR does / why we need it**:
The SBOM generator extension supports multiple generation modes, of which only the `bdba` mode requires the `secret-factory-bdba` secret to be present. Therefore, make the secret mount optional so that the pod can be scheduled even if no secret is available.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy operator
The BDBA secret mount is now optional for the SBOM generator extension
```
