### PR TITLE
[hotfix-0.1348] Skip issue update if artefact is filtered out

### DIFF
--- a/src/issue_replicator/__main__.py
+++ b/src/issue_replicator/__main__.py
@@ -317,6 +317,10 @@ def replicate_issue_for_finding_type(
     finding_type = finding_cfg.type
     finding_source = finding_type.datasource()
 
+    if not finding_cfg.matches(artefact):
+        logger.info(f'skipping issue update for {finding_type=} (artefact is filtered out)')
+        return
+
     logger.info(f'updating issues for {finding_type=} and {finding_source=}')
 
     artefact_group = finding_cfg.issues.strip_artefact(
@@ -340,7 +344,7 @@ def replicate_issue_for_finding_type(
     artefacts = tuple({cs.artefact for cs in active_compliance_snapshots})
     logger.info(f'{len(artefacts)=}')
 
-    if is_in_bom := len(active_compliance_snapshots) > 0 and finding_cfg.matches(artefact):
+    if is_in_bom := len(active_compliance_snapshots) > 0:
         findings = _iter_findings_for_artefact(
             delivery_service_client=delivery_service_client,
             artefacts=artefacts,


### PR DESCRIPTION
**What this PR does / why we need it**:
It is possible to configure artefact filters per finding type to shortcut scans. In the past, filtered out artefacts were still processed in the issue replicator to ensure once openend issues are still going to be closed if the artefact has been filtered out only at a later point in time. However, this required multiple database queries as well as expensive GitHub API calls (bulk issue fetching) for a very minor use case.
Therefore, early-skip artefacts which are filtered out and leave issue closing to a (tbd) follow-up process.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy operator
The issue replicator now early-skips artefacts which are filtered out for a specific finding type, thus potentially leaving issues open for artefacts which were once included by the filter configuration but then excluded at a later point in time
```
