### PR TITLE
fix(packages): Pin `odg-core-libs` version during image build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,8 @@ jobs:
       - prepare
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.packages.outputs.version }}
     steps:
       - name: install setuptools
         run: |
@@ -34,6 +36,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
       - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@v1
       - name: create distribution packages
+        id: packages
         run: |
           set -eu
 
@@ -44,6 +47,7 @@ jobs:
           fi
 
           echo "version: ${version}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
           # pass finalised version to setup
           export ODG_CORE_LIBS_VERSION=${version}
@@ -276,6 +280,8 @@ jobs:
       oci-platforms: linux/arm64,linux/amd64
       build-ctx-artefact: distribution-packages
       untar-build-ctx-artefact: distribution-packages.tar.gz
+      build-args: |
+        ODG_CORE_LIBS_VERSION=${{ needs.packages.outputs.version }}
       ocm-labels: |
         name: gardener.cloud/cve-categorisation
         value:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ COPY src/malware/clamav_entrypoint.sh /
 COPY src/malware/clamd.conf /etc/clamav/clamd.conf
 COPY --from=cbomkit-theia-builder /cbomkit-theia/cbomkit-theia /usr/bin/cbomkit-theia
 
+ARG ODG_CORE_LIBS_VERSION
+
 RUN --mount=type=bind,source=/dist,target=/dist \
     apk add --no-cache \
     bash \
@@ -40,7 +42,7 @@ RUN --mount=type=bind,source=/dist,target=/dist \
 && update-ca-certificates \
 && mkdir -p $HOME/.config/pip \
 && echo -e "[global]\nbreak-system-packages = true" >> $HOME/.config/pip/pip.conf \
-&& pip3 install --upgrade --no-cache-dir --find-links ./dist odg-core-libs \
+&& pip3 install --upgrade --no-cache-dir --find-links ./dist odg-core-libs==${ODG_CORE_LIBS_VERSION} \
 && apk del --no-cache \
     libc-dev \
     libffi-dev \


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the package is also published to PyPI, it must be ensured that the version of the current build (e.g. a hotfix version) is used instead of the greatest available version (e.g. from PyPI).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
The `odg-core-libs` version is now pinned during the image build
```
