### PR TITLE
refactor(asset-to-owner): Use more user centric error messages

### DIFF
--- a/src/components.py
+++ b/src/components.py
@@ -513,8 +513,11 @@ class ComponentResponsibles(aiohttp.web.View):
                 statuses.append(
                     responsibles.Status(
                         type='error',
-                        msg='responsibles-heuristic was not able to determine responsibles as '
-                        '(github) statistics are incomplete',
+                        msg='Automatic assignment is unavailable because required data from GitHub'
+                        ' is not accessible. This is a GitHub limitation, not an issue with your ODG'
+                        ' configuration. Please assign this issue manually and consider configuring'
+                        ' explicit assignees for this component via OCM labels to address this'
+                        ' sustainably.',
                     ),
                 )
 

--- a/src/issue_replicator/github.py
+++ b/src/issue_replicator/github.py
@@ -1739,8 +1739,8 @@ def create_issue(
 
         if assignees_statuses:
             comment_body = textwrap.dedent("""\
-                There have been anomalies during initial ticket assignment, please see details below:
-                | Message Type | Message |
+                Automatic assignment encountered problems. See details below:
+                | Status | Details |
                 | --- | --- |""")
             for status in assignees_statuses:
                 comment_body += f'\n|`{status.type}`|`{status.msg}`'


### PR DESCRIPTION
This error is end-user facing.
Let's be less technical and drop details.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy user
If automatic issue assignment fails, there is now a more meaningful and user friendly message added as comment.
```
