### PR TITLE
fix(ghas): Also query generic secret alerts

### DIFF
--- a/src/ghas.py
+++ b/src/ghas.py
@@ -472,12 +472,6 @@ def scan(
     all_metadata_keys = set()
 
     now = datetime.datetime.now(tz=datetime.timezone.utc)
-    all_existing_metadata = [
-        odg.model.ArtefactMetadata.from_dict(raw)
-        for raw in delivery_service_client.query_metadata(
-            type=odg.model.Datatype.GHAS_FINDING,
-        )
-    ]
 
     for finding in create_ghas_findings(
         ghas_config=ghas_config,
@@ -511,6 +505,13 @@ def scan(
 
         all_metadata.extend(metadata)
         all_metadata_keys.update([metadatum.key for metadatum in metadata])
+
+    all_existing_metadata = [
+        odg.model.ArtefactMetadata.from_dict(raw)
+        for raw in delivery_service_client.query_metadata(
+            type=odg.model.Datatype.GHAS_FINDING,
+        )
+    ]
 
     all_stale_metadata = [
         metadatum for metadatum in all_existing_metadata if metadatum.key not in all_metadata_keys

--- a/src/ghas.py
+++ b/src/ghas.py
@@ -162,6 +162,18 @@ def get_secret_alerts(
     github_hostname: str,
     org: str,
     secret_factory: secret_mgmt.SecretFactory,
+    secret_types: tuple[str, ...] = (
+        'ec_private_key',
+        'generic_private_key',
+        'http_basic_authentication_header',
+        'http_bearer_authentication_header',
+        'mongodb_connection_string',
+        'mysql_connection_url',
+        'openssh_private_key',
+        'pgp_private_key',
+        'postgres_connection_string',
+        'rsa_private_key',
+    ),  # https://docs.github.com/en/code-security/reference/secret-security/supported-secret-scanning-patterns#supported-generic-patterns
 ) -> collections.abc.Generator[SecretAlert]:
     """
     Fetch open secret scanning alerts using authenticated GitHub client.
@@ -171,12 +183,31 @@ def get_secret_alerts(
     )
 
     count = 0
+    seen_urls = set()
+
+    # default alerts
     for alert_raw in github_api_request_paginated(
         url=url,
         secret_factory=secret_factory,
     ):
         count += 1
-        yield dacite.from_dict(SecretAlert, alert_raw)
+        alert = dacite.from_dict(SecretAlert, alert_raw)
+        yield alert
+        seen_urls.add(alert.url)
+
+    # generic alerts
+    url = f'{url}&secret_type={",".join(secret_types)}'
+
+    for alert_raw in github_api_request_paginated(
+        url=url,
+        secret_factory=secret_factory,
+    ):
+        alert = dacite.from_dict(SecretAlert, alert_raw)
+        if alert.url not in seen_urls:
+            # deduplicating, as we are effectively quering the same data source twice
+            seen_urls.add(alert.url)
+            yield alert
+            count += 1
 
     logger.info(f'found {count} secret alerts for {github_hostname}/{org}')
 
@@ -441,7 +472,6 @@ def scan(
     all_metadata_keys = set()
 
     now = datetime.datetime.now(tz=datetime.timezone.utc)
-
     all_existing_metadata = [
         odg.model.ArtefactMetadata.from_dict(raw)
         for raw in delivery_service_client.query_metadata(


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the GHAS extension does only filter for "default" secret alerts.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix operator
GitHub Secret Scanner Alert Extension will now also properly tracking "Generic" alerts.
```
