### PR TITLE
fix(ci): Support async tests (again)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -249,8 +249,6 @@ jobs:
           if ! pip3 install --pre --upgrade --break-system-packages \
             --find-links /tmp/dist \
             -r requirements-dev.txt \
-            "pytest<9.1" \
-            pytest-asyncio \
               > /tmp/pip3-install.log; then
             echo "error while trying to install packages:"
             cat /tmp/pip3-install.log

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ aiohttp-devtools
 aiosqlite
 greenlet
 numpy
+pytest<9.1 # pin for now due to regression
 pytest-asyncio
 scipy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,5 @@ aiohttp-devtools
 aiosqlite
 greenlet
 numpy
+pytest-asyncio
 scipy


### PR DESCRIPTION
**What this PR does / why we need it**:
When running tests locally without the package installed, the tests fail with:

```
FAILED src/test/test_compliance_summary.py::test_vulnerability - Failed: async def functions are not natively supported.
FAILED src/test/test_compliance_summary.py::test_malware - Failed: async def functions are not natively supported.
FAILED src/test/test_compliance_summary.py::test_licenses - Failed: async def functions are not natively supported.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
Test suite now supports asynchronous test functions
```
