### PR TITLE
feat(codeql): add CodeQL enablement check as a dedicated extension

### DIFF
--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -533,12 +533,15 @@ extensions_cfg:
     interval: 86400 # 24h
     # @param extensions_cfg.codeql.languages list of programming languages to check CodeQL coverage
     # for. A finding is emitted for each language that is present in the repository but not actively
-    # scanned by CodeQL. Must be non-empty; if empty, all artefacts are skipped.
+    # scanned by CodeQL. Use CodeQL language identifiers, which may differ from GitHub language
+    # names (e.g. 'javascript-typescript' covers both JavaScript and TypeScript, 'c-cpp' covers
+    # C and C++). See supported languages:
+    # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed
     # e.g.
     # languages:
     #   - go
     #   - python
-    #   - java
+    #   - javascript-typescript
     languages:
       - ""
     # @param extensions_cfg.codeql.on_unsupported behaviour in case the detected artefact

--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -533,15 +533,14 @@ extensions_cfg:
     interval: 86400 # 24h
     # @param extensions_cfg.codeql.languages list of programming languages to check CodeQL coverage
     # for. A finding is emitted for each language that is present in the repository but not actively
-    # scanned by CodeQL. Use CodeQL language identifiers, which may differ from GitHub language
-    # names (e.g. 'javascript-typescript' covers both JavaScript and TypeScript, 'c-cpp' covers
-    # C and C++). See supported languages:
-    # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed
+    # scanned by CodeQL. Use the language names as returned by the GitHub repository languages API
+    # (e.g. 'go', 'python', 'javascript'). The extension automatically handles CodeQL-specific
+    # language identifiers (e.g. maps 'javascript-typescript' back to 'javascript').
     # e.g.
     # languages:
     #   - go
     #   - python
-    #   - javascript-typescript
+    #   - javascript
     languages:
       - ""
     # @param extensions_cfg.codeql.on_unsupported behaviour in case the detected artefact

--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -531,18 +531,18 @@ extensions_cfg:
     # @param extensions_cfg.codeql.interval time (in seconds) after which a component should be
     # re-checked the latest
     interval: 86400 # 24h
-    # @param extensions_cfg.codeql.languages list of programming languages to check CodeQL coverage
-    # for. A finding is emitted for each language that is present in the repository but not actively
-    # scanned by CodeQL. Use the language names as returned by the GitHub repository languages API
-    # (e.g. 'go', 'python', 'javascript'). The extension automatically handles CodeQL-specific
-    # language identifiers (e.g. maps 'javascript-typescript' back to 'javascript').
+    # @param extensions_cfg.codeql.languages optional list of languages to exclude from CodeQL
+    # coverage checks. By default (empty list), a finding is created for every language present in
+    # the repository that is not actively scanned by CodeQL. If non-empty, the listed languages are
+    # skipped regardless of their CodeQL status — useful to suppress findings for languages CodeQL
+    # does not support (e.g. 'yaml', 'dockerfile', 'shell'). Use GitHub repository language names.
+    # See: https://docs.github.com/en/rest/repos/repos#list-repository-languages
     # e.g.
     # languages:
-    #   - go
-    #   - python
-    #   - javascript
-    languages:
-      - ""
+    #   - yaml
+    #   - dockerfile
+    #   - shell
+    languages: []
     # @param extensions_cfg.codeql.on_unsupported behaviour in case the detected artefact
     # kind/type/access is not supported
     # options:

--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -517,8 +517,10 @@ extensions_cfg:
     on_unsupported: warning
 
   # @param extensions_cfg.codeql worker which checks whether GitHub Advanced Security CodeQL is
-  # enabled for each OCM source artefact and creates findings for languages that are configured but
-  # not actively scanned
+  # actively scanning each OCM source artefact. A finding is created for every language present in
+  # the repository that is not covered by an active CodeQL analysis — including the case where
+  # CodeQL is not enabled at all. Languages not supported by CodeQL (e.g. yaml, dockerfile) can be
+  # excluded via the languages parameter to suppress false positives.
   codeql:
     # @param extensions_cfg.codeql.enabled allows disabling of extension without removing its
     # configuration

--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -516,6 +516,39 @@ extensions_cfg:
     # - warning: skip processing and log a warning message (default)
     on_unsupported: warning
 
+  # @param extensions_cfg.codeql worker which checks whether GitHub Advanced Security CodeQL is
+  # enabled for each OCM source artefact and creates findings for languages that are configured but
+  # not actively scanned
+  codeql:
+    # @param extensions_cfg.codeql.enabled allows disabling of extension without removing its
+    # configuration
+    enabled: true
+    # @param extensions_cfg.codeql.delivery_service_url url to access the delivery-service (cluster
+    # internal url is sufficient)
+    # e.g.
+    # delivery_service_url: http://delivery-service.<namespace>.svc.cluster.local:8080
+    delivery_service_url: ""
+    # @param extensions_cfg.codeql.interval time (in seconds) after which a component should be
+    # re-checked the latest
+    interval: 86400 # 24h
+    # @param extensions_cfg.codeql.languages list of programming languages to check CodeQL coverage
+    # for. A finding is emitted for each language that is present in the repository but not actively
+    # scanned by CodeQL. Must be non-empty; if empty, all artefacts are skipped.
+    # e.g.
+    # languages:
+    #   - go
+    #   - python
+    #   - java
+    languages:
+      - ""
+    # @param extensions_cfg.codeql.on_unsupported behaviour in case the detected artefact
+    # kind/type/access is not supported
+    # options:
+    # - fail: raise an exception
+    # - ignore: skip processing
+    # - warning: skip processing and log a warning message (default)
+    on_unsupported: warning
+
   # @param extensions_cfg.issue_replicator worker which takes care of the GitHub issue lifecycle for
   # detected findings
   issue_replicator:
@@ -1168,6 +1201,7 @@ features_cfg:
 findings:
     # @param findings[].type type of finding this configuration is used for
     # options:
+    # - finding/codeql
     # - finding/crypto
     # - finding/diki
     # - finding/falco
@@ -1548,6 +1582,7 @@ profiles:
     # @param profiles[].finding_types list of finding types which should be displayed for users who
     # selected this profile in the delivery-dashboard
     # options:
+    # - finding/codeql
     # - finding/crypto
     # - finding/diki
     # - finding/falco

--- a/charts/extensions/Chart.yaml
+++ b/charts/extensions/Chart.yaml
@@ -29,6 +29,9 @@ dependencies:
   - name: ghas
     repository: file://charts/ghas
     condition: ghas.enabled
+  - name: codeql
+    repository: file://charts/codeql
+    condition: codeql.enabled
   - name: issue-replicator
     repository: file://charts/issue-replicator
     condition: issue-replicator.enabled

--- a/charts/extensions/charts/codeql/Chart.yaml
+++ b/charts/extensions/charts/codeql/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: codeql
+version: 0.1.0

--- a/charts/extensions/charts/codeql/templates/codeql.yaml
+++ b/charts/extensions/charts/codeql/templates/codeql.yaml
@@ -1,0 +1,111 @@
+{{- $podName := "codeql" }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $podName }}
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+  {{- if default dict (.Values.deployment).annotations }}
+  annotations:
+  {{- range $annotation, $value := .Values.deployment.annotations }}
+    {{ $annotation }}: {{ $value }}
+  {{- end }}
+  {{- end }}
+spec:
+  replicas: 0 # will be scaled automatically by backlog-controller
+  selector:
+    matchLabels:
+      app: {{ $podName }}
+      delivery-gear.gardener.cloud/service: codeql
+  template:
+    metadata:
+      labels:
+        app: {{ $podName }}
+        delivery-gear.gardener.cloud/service: codeql
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: {{ $podName }}
+      terminationGracePeriodSeconds: 300 # 5 min
+      containers:
+        - name: {{ $podName }}
+          image: {{ include "image" .Values.global.image }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - -m
+            - codeql
+          securityContext:
+            allowPrivilegeEscalation: false
+          env:
+            - name: SECRET_FACTORY_PATH
+              value: /secrets
+            - name: EXTENSIONS_CFG_PATH
+              value: /extensions_cfg/extensions_cfg
+            - name: FINDINGS_CFG_PATH
+              value: /findings_cfg/findings_cfg
+            - name: OCM_REPO_MAPPINGS_PATH
+              value: /ocm_repo_mappings/ocm_repo_mappings
+            - name: K8S_TARGET_NAMESPACE
+              value: {{ .Values.target_namespace | default .Release.Namespace }}
+          volumeMounts:
+            - name: github
+              mountPath: /secrets/github
+            - name: github-app
+              mountPath: /secrets/github-app
+            - name: extensions-cfg
+              mountPath: /extensions_cfg
+            - name: findings-cfg
+              mountPath: /findings_cfg
+            - name: ocm-repo-mappings
+              mountPath: /ocm_repo_mappings
+              readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - sleep
+                  - "60"
+          resources:
+            requests:
+              memory: 100Mi
+              cpu: 250m
+            limits:
+              memory: 300Mi
+              cpu: 500m
+      volumes:
+        - name: github
+          secret:
+            secretName: secret-factory-github
+            optional: true
+        - name: github-app
+          secret:
+            secretName: secret-factory-github-app
+            optional: true
+        - name: extensions-cfg
+          configMap:
+            name: extensions-cfg
+        - name: findings-cfg
+          configMap:
+            name: findings-cfg
+        - name: ocm-repo-mappings
+          configMap:
+            name: ocm-repo-mappings
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-from-codeql
+  namespace: {{ .Values.target_namespace | default .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $podName }}
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # Allows all egress traffic to any destination and port

--- a/charts/extensions/crds/odg.yaml
+++ b/charts/extensions/crds/odg.yaml
@@ -57,6 +57,7 @@ spec:
                     - delivery-db-backup
                     - delivery-service
                     - envoy-gateway
+                    - codeql
                     - findings-report
                     - ghas
                     - issue-replicator

--- a/charts/extensions/values.yaml
+++ b/charts/extensions/values.yaml
@@ -21,6 +21,10 @@ clamav:
   deployment:
     annotations: []
   enabled: false
+codeql:
+  deployment:
+    annotations: []
+  enabled: false
 crypto:
   deployment:
     annotations: []

--- a/extension-definitions.yaml
+++ b/extension-definitions.yaml
@@ -493,6 +493,32 @@ installation:
     name: ocm.software/open-delivery-gear/core
     version: 0.1355.0-dev
   value_templates:
+  - helm_attribute: codeql.target_namespace
+    helm_chart_name: extensions
+    value: ${target_namespace}
+    value_type: python-string-template
+  - helm_attribute: codeql.enabled
+    helm_chart_name: extensions
+    value: true
+    value_type: literal
+name: codeql
+outputs: []
+---
+dependencies:
+- delivery-service
+installation:
+  ocm_references:
+  - artefact:
+      name: extensions
+      version: 0.1355.0-dev
+    helm_chart_name: extensions
+    mappings:
+    - artefact_type: helmchart-imagemap
+      name: extensions
+      version: 0.1355.0-dev
+    name: ocm.software/open-delivery-gear/core
+    version: 0.1355.0-dev
+  value_templates:
   - helm_attribute: sbom-generator.target_namespace
     helm_chart_name: extensions
     value: ${target_namespace}

--- a/src/artefact_enumerator.py
+++ b/src/artefact_enumerator.py
@@ -382,6 +382,23 @@ def _process_compliance_snapshot_of_artefact(
             uncommitted_backlog_items.append(uncommitted_backlog_item)
 
     if (
+        extensions_cfg.codeql
+        and extensions_cfg.codeql.enabled
+        and extensions_cfg.codeql.is_supported(artefact_kind=artefact.artefact_kind)
+    ):
+        compliance_snapshot, uncommitted_backlog_item = _create_backlog_item_for_extension(
+            finding_cfgs=finding_cfgs,
+            finding_types=(odg.model.Datatype.CODEQL_FINDING,),
+            artefact=artefact,
+            compliance_snapshot=compliance_snapshot,
+            service=odg.extensions_cfg.Services.CODEQL,
+            interval_seconds=extensions_cfg.codeql.interval,
+            now=now,
+        )
+        if uncommitted_backlog_item:
+            uncommitted_backlog_items.append(uncommitted_backlog_item)
+
+    if (
         extensions_cfg.osid
         and extensions_cfg.osid.enabled
         and extensions_cfg.osid.is_supported(artefact_kind=artefact.artefact_kind)

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -33,6 +33,7 @@ k8s.logging.configure_kubernetes_logging()
 _CODEQL_LANGUAGE_ALIASES: dict[str, set[str]] = {
     'javascript-typescript': {'javascript', 'typescript'},
     'c-cpp': {'c', 'c++'},
+    'java-kotlin': {'java', 'kotlin'},
 }
 
 
@@ -169,10 +170,10 @@ def iter_artefact_metadata(
         logger.info(f'did not find source node for {artefact=}, skipping...')
         return
 
-    if not codeql_config.is_supported(access=source_node.source.access):
+    if not codeql_config.is_supported(access_type=source_node.source.access.type):
         if codeql_config.on_unsupported is odg.extensions_cfg.WarningVerbosities.FAIL:
             raise TypeError(
-                f'{type(source_node.source.access)} is not supported by the CodeQL extension',
+                f'{source_node.source.access.type} is not supported by the CodeQL extension',
             )
         return
 

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -145,10 +145,16 @@ def iter_artefact_metadata(
         secret_factory=secret_factory,
     )
 
-    if codeql_enabled:
+    if not repo_url:
         return
 
-    if not repo_url:
+    if codeql_config.languages and language not in codeql_config.languages:
+        logger.info(
+            f'skipping CodeQL check for {repo_url=}: {language=} not in configured {codeql_config.languages=}',
+        )
+        return
+
+    if codeql_enabled:
         return
 
     categorisation = odg.findings.categorise_finding(

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -69,11 +69,6 @@ def fetch_repo_info(
 
     org, repo, api_base = coords
 
-    if not access.ref:
-        logger.warning(f'No ref configured in OCM access for {repo_url=}, skipping CodeQL check')
-        return repo_url, set(), set()
-
-    ref = access.ref if access.ref.startswith('refs/') else f'refs/heads/{access.ref}'
     languages_raw, _ = github_util.github_api_request(
         url=f'{api_base}/repos/{org}/{repo}/languages',
         secret_factory=secret_factory,
@@ -81,6 +76,20 @@ def fetch_repo_info(
     repo_languages = set()
     if isinstance(languages_raw, dict):
         repo_languages = {lang.lower() for lang in languages_raw}
+
+    repo_info, _ = github_util.github_api_request(
+        url=f'{api_base}/repos/{org}/{repo}',
+        secret_factory=secret_factory,
+    )
+
+    if access.ref:
+        ref = access.ref if access.ref.startswith('refs/') else f'refs/heads/{access.ref}'
+    elif isinstance(repo_info, dict) and (default_branch := repo_info.get('default_branch')):
+        ref = f'refs/heads/{default_branch}'
+        logger.info(f'No ref in OCM access for {repo_url=}, falling back to default branch {default_branch!r}')
+    else:
+        logger.warning(f'No ref in OCM access and could not determine default branch for {repo_url=}, skipping')
+        return repo_url, set(), set()
 
     active_languages = set()
     for analysis in github_util.github_api_request_paginated(

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -258,7 +258,17 @@ def scan(
     secret_factory: secret_mgmt.SecretFactory,
     **kwargs,
 ):
-    all_metadata = list(
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    existing_findings = [
+        odg.model.ArtefactMetadata.from_dict(raw)
+        for raw in delivery_service_client.query_metadata(
+            artefacts=[artefact],
+            type=odg.model.Datatype.CODEQL_FINDING,
+        )
+    ]
+
+    new_metadata = list(
         iter_artefact_metadata(
             artefact=artefact,
             component_descriptor_lookup=component_descriptor_lookup,
@@ -267,8 +277,38 @@ def scan(
             secret_factory=secret_factory,
         ),
     )
+    new_keys = {m.data.key for m in new_metadata if m.meta.type == odg.model.Datatype.CODEQL_FINDING}
 
-    delivery_service_client.update_metadata(data=all_metadata)
+    for stale in existing_findings:
+        if stale.data.key in new_keys:
+            continue
+
+        rescoring = odg.model.ArtefactMetadata(
+            artefact=stale.artefact,
+            meta=odg.model.Metadata(
+                datasource=stale.meta.datasource,
+                type=odg.model.Datatype.RESCORING,
+                creation_date=now,
+                last_update=now,
+            ),
+            data=odg.model.CustomRescoring(
+                finding=odg.model.RescoreCodeqlFinding(
+                    codeql_status=stale.data.codeql_status,
+                    repo_url=stale.data.repo_url,
+                    language=stale.data.language,
+                ),
+                referenced_type=odg.model.Datatype.CODEQL_FINDING,
+                severity='accepted',
+                user=odg.model.User(
+                    username='codeql-extension-auto-rescoring',
+                    type='codeql-extension-user',
+                ),
+                comment='Automatically rescored: CodeQL is now enabled for this language.',
+            ),
+        )
+        new_metadata.append(rescoring)
+
+    delivery_service_client.update_metadata(data=new_metadata)
 
 
 def main():

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -60,20 +60,21 @@ def _parse_github_coords(
 def fetch_repo_info(
     source_node: ocm.iter.SourceNode,
     secret_factory: secret_mgmt.SecretFactory,
-) -> tuple[str | None, set[str], set[str]]:
+) -> tuple[str | None, set[str], set[str], bool]:
     """
-    Returns (repo_url, repo_languages, active_codeql_languages).
+    Returns (repo_url, repo_languages, active_codeql_languages, api_success).
 
-    repo_languages: languages present in the repo (from /languages endpoint).
-    active_codeql_languages: languages CodeQL is currently scanning on the
-    default branch (from code-scanning/analyses environment field).
+    api_success is False when the GitHub API could not be reached (e.g. auth
+    failure, network error). Callers must not treat empty language sets as
+    "CodeQL disabled" when api_success is False — stale findings should be
+    preserved rather than rescored in that case.
     """
     access = source_node.source.access
     repo_url = access.repoUrl
     coords = _parse_github_coords(repo_url)
     if not coords:
         logger.warning(f'Cannot parse org/repo from {repo_url=}')
-        return repo_url, set(), set()
+        return repo_url, set(), set(), False
 
     org, repo, api_base = coords
 
@@ -81,9 +82,15 @@ def fetch_repo_info(
         url=f'{api_base}/repos/{org}/{repo}/languages',
         secret_factory=secret_factory,
     )
-    repo_languages = set()
-    if isinstance(languages_raw, dict):
-        repo_languages = {lang.lower() for lang in languages_raw}
+    if languages_raw is None:
+        logger.warning(f'Failed to fetch repository languages for {repo_url=}, skipping')
+        return repo_url, set(), set(), False
+
+    repo_languages = (
+        {lang.lower() for lang in languages_raw}
+        if isinstance(languages_raw, dict)
+        else set()
+    )
 
     repo_info, _ = github_util.github_api_request(
         url=f'{api_base}/repos/{org}/{repo}',
@@ -103,7 +110,7 @@ def fetch_repo_info(
             f'No ref in OCM access and could not determine default branch '
             f'for {repo_url=}, skipping',
         )
-        return repo_url, set(), set()
+        return repo_url, set(), set(), False
 
     active_languages = set()
     for analysis in github_util.github_api_request_paginated(
@@ -126,7 +133,7 @@ def fetch_repo_info(
     logger.info(
         f'{repo_url=}: {repo_languages=}, active CodeQL languages={active_languages}',
     )
-    return repo_url, repo_languages, active_languages
+    return repo_url, repo_languages, active_languages, True
 
 
 def iter_artefact_metadata(
@@ -135,8 +142,11 @@ def iter_artefact_metadata(
     codeql_finding_config: odg.findings.Finding,
     codeql_config: odg.extensions_cfg.CodeqlConfig,
     secret_factory: secret_mgmt.SecretFactory,
+    existing_findings: list[odg.model.ArtefactMetadata] | None = None,
     creation_timestamp: datetime.datetime = datetime.datetime.now(datetime.timezone.utc),
 ) -> collections.abc.Generator[odg.model.ArtefactMetadata, None, None]:
+    if existing_findings is None:
+        existing_findings = []
     if not codeql_finding_config.matches(artefact):
         logger.info(f'CodeQL findings are filtered out for {artefact=}, skipping...')
         return
@@ -191,12 +201,12 @@ def iter_artefact_metadata(
         )
         return
 
-    repo_url, repo_languages, active_languages = fetch_repo_info(
+    repo_url, repo_languages, active_languages, api_success = fetch_repo_info(
         source_node=source_node,
         secret_factory=secret_factory,
     )
 
-    if not repo_url:
+    if not repo_url or not api_success:
         return
 
     for language in [lang.lower() for lang in codeql_config.languages]:
@@ -215,6 +225,40 @@ def iter_artefact_metadata(
             )
             if finding:
                 yield finding
+
+    new_keys = {
+        f'not-enabled|{repo_url}|{lang.lower()}'
+        for lang in codeql_config.languages
+        if lang.lower() in repo_languages and lang.lower() not in active_languages
+    }
+
+    for stale in existing_findings:
+        if stale.data.key in new_keys:
+            continue
+        rescoring = odg.model.ArtefactMetadata(
+            artefact=stale.artefact,
+            meta=odg.model.Metadata(
+                datasource=stale.meta.datasource,
+                type=odg.model.Datatype.RESCORING,
+                creation_date=creation_timestamp,
+                last_update=creation_timestamp,
+            ),
+            data=odg.model.CustomRescoring(
+                finding=odg.model.RescoreCodeqlFinding(
+                    codeql_status=stale.data.codeql_status,
+                    repo_url=stale.data.repo_url,
+                    language=stale.data.language,
+                ),
+                referenced_type=odg.model.Datatype.CODEQL_FINDING,
+                severity='accepted',
+                user=odg.model.User(
+                    username='codeql-extension-auto-rescoring',
+                    type='codeql-extension-user',
+                ),
+                comment='Automatically rescored: CodeQL is now enabled for this language.',
+            ),
+        )
+        yield rescoring
 
 
 def _make_finding(
@@ -272,8 +316,6 @@ def scan(
     secret_factory: secret_mgmt.SecretFactory,
     **kwargs,
 ):
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
-
     existing_findings = [
         odg.model.ArtefactMetadata.from_dict(raw)
         for raw in delivery_service_client.query_metadata(
@@ -289,38 +331,9 @@ def scan(
             codeql_finding_config=codeql_finding_config,
             codeql_config=extension_cfg,
             secret_factory=secret_factory,
+            existing_findings=existing_findings,
         ),
     )
-    new_keys = {m.data.key for m in new_metadata if m.meta.type == odg.model.Datatype.CODEQL_FINDING}
-
-    for stale in existing_findings:
-        if stale.data.key in new_keys:
-            continue
-
-        rescoring = odg.model.ArtefactMetadata(
-            artefact=stale.artefact,
-            meta=odg.model.Metadata(
-                datasource=stale.meta.datasource,
-                type=odg.model.Datatype.RESCORING,
-                creation_date=now,
-                last_update=now,
-            ),
-            data=odg.model.CustomRescoring(
-                finding=odg.model.RescoreCodeqlFinding(
-                    codeql_status=stale.data.codeql_status,
-                    repo_url=stale.data.repo_url,
-                    language=stale.data.language,
-                ),
-                referenced_type=odg.model.Datatype.CODEQL_FINDING,
-                severity='accepted',
-                user=odg.model.User(
-                    username='codeql-extension-auto-rescoring',
-                    type='codeql-extension-user',
-                ),
-                comment='Automatically rescored: CodeQL is now enabled for this language.',
-            ),
-        )
-        new_metadata.append(rescoring)
 
     delivery_service_client.update_metadata(data=new_metadata)
 

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -146,8 +146,10 @@ def iter_artefact_metadata(
     codeql_config: odg.extensions_cfg.CodeqlConfig,
     secret_factory: secret_mgmt.SecretFactory,
     existing_findings: list[odg.model.ArtefactMetadata],
-    creation_timestamp: datetime.datetime = datetime.datetime.now(datetime.timezone.utc),
+    creation_timestamp: datetime.datetime | None = None,
 ) -> collections.abc.Generator[odg.model.ArtefactMetadata, None, None]:
+    if creation_timestamp is None:
+        creation_timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
     if not codeql_finding_config.matches(artefact):
         logger.info(f'CodeQL findings are filtered out for {artefact=}, skipping...')
         return

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -31,6 +31,8 @@ k8s.logging.configure_kubernetes_logging()
 def _parse_github_coords(
     repo_url: str,
 ) -> tuple[str, str, str] | None:
+    if not repo_url.startswith('http'):
+        repo_url = f'https://{repo_url}'
     parsed = urllib.parse.urlparse(repo_url)
     if not parsed.hostname:
         logger.warning(f'Cannot determine hostname from {repo_url=}')

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -47,38 +47,36 @@ def _parse_github_coords(
 def fetch_repo_info(
     source_node: ocm.iter.SourceNode,
     secret_factory: secret_mgmt.SecretFactory,
-) -> tuple[str | None, str | None, set[str]]:
+) -> tuple[str | None, set[str], set[str]]:
     """
-    Returns (repo_url, settings_url, active_codeql_languages).
+    Returns (repo_url, repo_languages, active_codeql_languages).
 
-    active_codeql_languages is the set of languages CodeQL is currently
-    scanning on the default branch, extracted from code-scanning/analyses
-    environment field. Empty set means CodeQL is not enabled for any language.
+    repo_languages: languages present in the repo (from /languages endpoint).
+    active_codeql_languages: languages CodeQL is currently scanning on the
+    default branch (from code-scanning/analyses environment field).
     """
     access = source_node.source.access
     if not isinstance(access, ocm.GithubAccess):
         logger.info(
             f'source access is not GithubAccess for {source_node.source.name}, skipping CodeQL check',
         )
-        return None, None, set()
+        return None, set(), set()
 
     repo_url = access.repoUrl
     coords = _parse_github_coords(repo_url)
     if not coords:
         logger.warning(f'Cannot parse org/repo from {repo_url=}')
-        return repo_url, None, set()
+        return repo_url, set(), set()
 
     org, repo, api_base = coords
 
-    repo_info, _ = ghas.github_api_request(
-        url=f'{api_base}/repos/{org}/{repo}',
+    languages_raw, _ = ghas.github_api_request(
+        url=f'{api_base}/repos/{org}/{repo}/languages',
         secret_factory=secret_factory,
     )
-
-    settings_url = None
-    if isinstance(repo_info, dict):
-        html_url = repo_info.get('html_url', repo_url)
-        settings_url = f'{html_url}/settings/security_analysis'
+    repo_languages = set()
+    if isinstance(languages_raw, dict):
+        repo_languages = {lang.lower() for lang in languages_raw}
 
     analyses = list(ghas.github_api_request_paginated(
         url=f'{api_base}/repos/{org}/{repo}/code-scanning/analyses?tool_name=CodeQL&ref=refs/heads/{access.branch or "main"}&per_page=100',
@@ -99,8 +97,10 @@ def fetch_repo_info(
         if lang := env.get('language'):
             active_languages.add(lang.lower())
 
-    logger.info(f'{repo_url=}: active CodeQL languages={active_languages}')
-    return repo_url, settings_url, active_languages
+    logger.info(
+        f'{repo_url=}: {repo_languages=}, active CodeQL languages={active_languages}',
+    )
+    return repo_url, repo_languages, active_languages
 
 
 def iter_artefact_metadata(
@@ -151,7 +151,14 @@ def iter_artefact_metadata(
         )
         return
 
-    repo_url, settings_url, active_languages = fetch_repo_info(
+    if not codeql_config.languages:
+        logger.warning(
+            f'No languages configured for CodeQL extension, skipping {artefact=}. '
+            'Set languages in codeql extension config to enable checks.',
+        )
+        return
+
+    repo_url, repo_languages, active_languages = fetch_repo_info(
         source_node=source_node,
         secret_factory=secret_factory,
     )
@@ -159,27 +166,17 @@ def iter_artefact_metadata(
     if not repo_url:
         return
 
-    languages_to_check = [l.lower() for l in codeql_config.languages] if codeql_config.languages else None
-
-    if languages_to_check is None:
-        if not active_languages:
-            yield _make_finding(
-                artefact=artefact,
-                codeql_finding_config=codeql_finding_config,
-                repo_url=repo_url,
-                settings_url=settings_url,
-                language=None,
-                creation_timestamp=creation_timestamp,
+    for language in [l.lower() for l in codeql_config.languages]:
+        if language not in repo_languages:
+            logger.info(
+                f'skipping CodeQL check for {language=}: not present in {repo_url=}',
             )
-        return
-
-    for language in languages_to_check:
+            continue
         if language not in active_languages:
             finding = _make_finding(
                 artefact=artefact,
                 codeql_finding_config=codeql_finding_config,
                 repo_url=repo_url,
-                settings_url=settings_url,
                 language=language,
                 creation_timestamp=creation_timestamp,
             )
@@ -191,8 +188,7 @@ def _make_finding(
     artefact: odg.model.ComponentArtefactId,
     codeql_finding_config: odg.findings.Finding,
     repo_url: str,
-    settings_url: str | None,
-    language: str | None,
+    language: str,
     creation_timestamp: datetime.datetime,
 ) -> odg.model.ArtefactMetadata | None:
     categorisation = odg.findings.categorise_finding(
@@ -213,7 +209,6 @@ def _make_finding(
             codeql_status=odg.model.CodeqlStatus.NOT_ENABLED,
             severity=categorisation.id,
             repo_url=repo_url,
-            settings_url=settings_url,
             language=language,
         ),
         discovery_date=creation_timestamp.date(),

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -210,6 +210,7 @@ def iter_artefact_metadata(
     if not repo_url or not api_success:
         return
 
+    new_keys = set()
     for language in [lang.lower() for lang in codeql_config.languages]:
         if language not in repo_languages:
             logger.info(
@@ -225,13 +226,8 @@ def iter_artefact_metadata(
                 creation_timestamp=creation_timestamp,
             )
             if finding:
+                new_keys.add(finding.data.key)
                 yield finding
-
-    new_keys = {
-        f'not-enabled|{repo_url}|{lang.lower()}'
-        for lang in codeql_config.languages
-        if lang.lower() in repo_languages and lang.lower() not in active_languages
-    }
 
     for stale in existing_findings:
         if stale.data.key in new_keys:

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -8,7 +8,6 @@ import urllib.parse
 
 import ci.log
 import cnudie.retrieve
-import ocm
 import ocm.iter
 
 import github_util
@@ -95,9 +94,15 @@ def fetch_repo_info(
         ref = access.ref if access.ref.startswith('refs/') else f'refs/heads/{access.ref}'
     elif isinstance(repo_info, dict) and (default_branch := repo_info.get('default_branch')):
         ref = f'refs/heads/{default_branch}'
-        logger.info(f'No ref in OCM access for {repo_url=}, falling back to default branch {default_branch!r}')
+        logger.info(
+            f'No ref in OCM access for {repo_url=}, '
+            f'falling back to default branch {default_branch!r}',
+        )
     else:
-        logger.warning(f'No ref in OCM access and could not determine default branch for {repo_url=}, skipping')
+        logger.warning(
+            f'No ref in OCM access and could not determine default branch '
+            f'for {repo_url=}, skipping',
+        )
         return repo_url, set(), set()
 
     active_languages = set()
@@ -194,7 +199,7 @@ def iter_artefact_metadata(
     if not repo_url:
         return
 
-    for language in [l.lower() for l in codeql_config.languages]:
+    for language in [lang.lower() for lang in codeql_config.languages]:
         if language not in repo_languages:
             logger.info(
                 f'skipping CodeQL check for {language=}: not present in {repo_url=}',

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -61,12 +61,6 @@ def fetch_repo_info(
     default branch (from code-scanning/analyses environment field).
     """
     access = source_node.source.access
-    if not isinstance(access, ocm.GithubAccess):
-        logger.info(
-            f'source access is not GithubAccess for {source_node.source.name}, skipping CodeQL check',
-        )
-        return None, set(), set()
-
     repo_url = access.repoUrl
     coords = _parse_github_coords(repo_url)
     if not coords:
@@ -141,6 +135,13 @@ def iter_artefact_metadata(
 
     if not source_node:
         logger.info(f'did not find source node for {artefact=}, skipping...')
+        return
+
+    if not codeql_config.is_supported(access=source_node.source.access):
+        if codeql_config.on_unsupported is odg.extensions_cfg.WarningVerbosities.FAIL:
+            raise TypeError(
+                f'{type(source_node.source.access)} is not supported by the CodeQL extension',
+            )
         return
 
     yield odg.model.ArtefactMetadata(

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -82,13 +82,11 @@ def fetch_repo_info(
     if isinstance(languages_raw, dict):
         repo_languages = {lang.lower() for lang in languages_raw}
 
-    analyses = list(github_util.github_api_request_paginated(
+    active_languages = set()
+    for analysis in github_util.github_api_request_paginated(
         url=f'{api_base}/repos/{org}/{repo}/code-scanning/analyses?tool_name=CodeQL&ref={ref}&per_page=100',
         secret_factory=secret_factory,
-    ))
-
-    active_languages = set()
-    for analysis in analyses:
+    ):
         if not isinstance(analysis, dict):
             continue
         env = analysis.get('environment', {})

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -145,11 +145,9 @@ def iter_artefact_metadata(
     codeql_finding_config: odg.findings.Finding,
     codeql_config: odg.extensions_cfg.CodeqlConfig,
     secret_factory: secret_mgmt.SecretFactory,
-    existing_findings: list[odg.model.ArtefactMetadata] | None = None,
+    existing_findings: list[odg.model.ArtefactMetadata],
     creation_timestamp: datetime.datetime = datetime.datetime.now(datetime.timezone.utc),
 ) -> collections.abc.Generator[odg.model.ArtefactMetadata, None, None]:
-    if existing_findings is None:
-        existing_findings = []
     if not codeql_finding_config.matches(artefact):
         logger.info(f'CodeQL findings are filtered out for {artefact=}, skipping...')
         return

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -103,7 +103,8 @@ def fetch_repo_info(
         if isinstance(env, str):
             try:
                 env = json.loads(env)
-            except Exception:
+            except Exception as e:
+                logger.warning(f'Failed to parse environment field {env!r}: {e}')
                 continue
         if lang := env.get('language'):
             active_languages.add(lang.lower())

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -59,7 +59,8 @@ def _parse_github_coords(
 
 
 def fetch_repo_info(
-    source_node: ocm.iter.SourceNode,
+    repo_url: str,
+    ref: str | None,
     secret_factory: secret_mgmt.SecretFactory,
 ) -> tuple[str | None, set[str], set[str], bool]:
     """
@@ -70,8 +71,6 @@ def fetch_repo_info(
     "CodeQL disabled" when api_success is False — stale findings should be
     preserved rather than rescored in that case.
     """
-    access = source_node.source.access
-    repo_url = access.repoUrl
     coords = _parse_github_coords(repo_url)
     if not coords:
         logger.warning(f'Cannot parse org/repo from {repo_url=}')
@@ -100,17 +99,17 @@ def fetch_repo_info(
         secret_factory=secret_factory,
     )
 
-    if access.ref:
-        ref = access.ref if access.ref.startswith('refs/') else f'refs/heads/{access.ref}'
+    if ref:
+        ref = ref if ref.startswith('refs/') else f'refs/heads/{ref}'
     elif isinstance(repo_info, dict) and (default_branch := repo_info.get('default_branch')):
         ref = f'refs/heads/{default_branch}'
         logger.info(
-            f'No ref in OCM access for {repo_url=}, '
+            f'No ref provided for {repo_url=}, '
             f'falling back to default branch {default_branch!r}',
         )
     else:
         logger.warning(
-            f'No ref in OCM access and could not determine default branch '
+            f'No ref provided and could not determine default branch '
             f'for {repo_url=}, skipping',
         )
         return repo_url, set(), set(), False
@@ -197,8 +196,10 @@ def iter_artefact_metadata(
         )
         return
 
+    access = source_node.source.access
     repo_url, repo_languages, active_languages, api_success = fetch_repo_info(
-        source_node=source_node,
+        repo_url=access.repoUrl,
+        ref=access.ref,
         secret_factory=secret_factory,
     )
 

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -28,6 +28,14 @@ logger = logging.getLogger(__name__)
 ci.log.configure_default_logging()
 k8s.logging.configure_kubernetes_logging()
 
+# CodeQL uses different language names than GitHub's /languages endpoint.
+# This mapping expands CodeQL language identifiers to their GitHub equivalents
+# so that config entries like 'javascript' match CodeQL's 'javascript-typescript'.
+_CODEQL_LANGUAGE_ALIASES: dict[str, set[str]] = {
+    'javascript-typescript': {'javascript', 'typescript'},
+    'c-cpp': {'c', 'c++'},
+}
+
 
 def _parse_github_coords(
     repo_url: str,
@@ -107,7 +115,8 @@ def fetch_repo_info(
                 logger.warning(f'Failed to parse environment field {env!r}: {e}')
                 continue
         if lang := env.get('language'):
-            active_languages.add(lang.lower())
+            lang = lang.lower()
+            active_languages.update(_CODEQL_LANGUAGE_ALIASES.get(lang, {lang}))
 
     logger.info(
         f'{repo_url=}: {repo_languages=}, active CodeQL languages={active_languages}',

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -197,13 +197,6 @@ def iter_artefact_metadata(
         )
         return
 
-    if not codeql_config.languages:
-        logger.warning(
-            f'No languages configured for CodeQL extension, skipping {artefact=}. '
-            'Set languages in codeql extension config to enable checks.',
-        )
-        return
-
     repo_url, repo_languages, active_languages, api_success = fetch_repo_info(
         source_node=source_node,
         secret_factory=secret_factory,
@@ -212,11 +205,13 @@ def iter_artefact_metadata(
     if not repo_url or not api_success:
         return
 
+    excluded_languages = {lang.lower() for lang in codeql_config.languages}
+
     new_keys = set()
-    for language in [lang.lower() for lang in codeql_config.languages]:
-        if language not in repo_languages:
+    for language in repo_languages:
+        if language in excluded_languages:
             logger.info(
-                f'skipping CodeQL check for {language=}: not present in {repo_url=}',
+                f'skipping CodeQL check for {language=}: excluded by config for {repo_url=}',
             )
             continue
         if language not in active_languages:

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -10,7 +10,6 @@ import cnudie.retrieve
 import ocm
 import ocm.iter
 
-import ctx_util
 import ghas
 import k8s.util
 import k8s.logging
@@ -276,12 +275,9 @@ def main():
         logger.info('CodeQL findings are disabled, exiting...')
         return
 
-    secret_factory = ctx_util.secret_factory()
-
     scan_callback = functools.partial(
         scan,
         codeql_finding_config=codeql_finding_config,
-        secret_factory=secret_factory,
     )
 
     odg.util.process_backlog_items(

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -2,6 +2,7 @@
 import collections.abc
 import datetime
 import functools
+import json
 import logging
 import urllib.parse
 
@@ -100,9 +101,8 @@ def fetch_repo_info(
             continue
         env = analysis.get('environment', {})
         if isinstance(env, str):
-            import json as _json
             try:
-                env = _json.loads(env)
+                env = json.loads(env)
             except Exception:
                 continue
         if lang := env.get('language'):

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -33,13 +33,17 @@ def _parse_github_coords(
     repo_url: str,
 ) -> tuple[str, str, str] | None:
     parsed = urllib.parse.urlparse(repo_url)
+    if not parsed.hostname:
+        logger.warning(f'Cannot determine hostname from {repo_url=}')
+        return None
     path_parts = parsed.path.strip('/').split('/')
     if len(path_parts) < 2:
         return None
     org, repo = path_parts[0], path_parts[1]
-    hostname = parsed.hostname or 'github.com'
     api_base = (
-        f'https://{hostname}/api/v3' if hostname != 'github.com' else 'https://api.github.com'
+        f'https://{parsed.hostname}/api/v3'
+        if parsed.hostname != 'github.com'
+        else 'https://api.github.com'
     )
     return org, repo, api_base
 
@@ -70,6 +74,11 @@ def fetch_repo_info(
 
     org, repo, api_base = coords
 
+    if not access.ref:
+        logger.warning(f'No ref configured in OCM access for {repo_url=}, skipping CodeQL check')
+        return repo_url, set(), set()
+
+    ref = access.ref if access.ref.startswith('refs/') else f'refs/heads/{access.ref}'
     languages_raw, _ = ghas.github_api_request(
         url=f'{api_base}/repos/{org}/{repo}/languages',
         secret_factory=secret_factory,
@@ -79,7 +88,7 @@ def fetch_repo_info(
         repo_languages = {lang.lower() for lang in languages_raw}
 
     analyses = list(ghas.github_api_request_paginated(
-        url=f'{api_base}/repos/{org}/{repo}/code-scanning/analyses?tool_name=CodeQL&ref=refs/heads/{access.branch or "main"}&per_page=100',
+        url=f'{api_base}/repos/{org}/{repo}/code-scanning/analyses?tool_name=CodeQL&ref={ref}&per_page=100',
         secret_factory=secret_factory,
     ))
 

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -47,23 +47,26 @@ def _parse_github_coords(
 def fetch_repo_info(
     source_node: ocm.iter.SourceNode,
     secret_factory: secret_mgmt.SecretFactory,
-) -> tuple[bool, str | None, str | None, str | None]:
+) -> tuple[str | None, str | None, set[str]]:
     """
-    Returns (codeql_enabled, repo_url, settings_url, language).
-    Makes two GitHub API calls: one to /repos for metadata, one to code-scanning/analyses.
+    Returns (repo_url, settings_url, active_codeql_languages).
+
+    active_codeql_languages is the set of languages CodeQL is currently
+    scanning on the default branch, extracted from code-scanning/analyses
+    environment field. Empty set means CodeQL is not enabled for any language.
     """
     access = source_node.source.access
     if not isinstance(access, ocm.GithubAccess):
         logger.info(
             f'source access is not GithubAccess for {source_node.source.name}, skipping CodeQL check',
         )
-        return False, None, None, None
+        return None, None, set()
 
     repo_url = access.repoUrl
     coords = _parse_github_coords(repo_url)
     if not coords:
         logger.warning(f'Cannot parse org/repo from {repo_url=}')
-        return False, repo_url, None, None
+        return repo_url, None, set()
 
     org, repo, api_base = coords
 
@@ -72,24 +75,32 @@ def fetch_repo_info(
         secret_factory=secret_factory,
     )
 
-    language = None
     settings_url = None
     if isinstance(repo_info, dict):
-        language = repo_info.get('language')
         html_url = repo_info.get('html_url', repo_url)
         settings_url = f'{html_url}/settings/security_analysis'
 
-    analyses, _ = ghas.github_api_request(
-        url=f'{api_base}/repos/{org}/{repo}/code-scanning/analyses?tool_name=CodeQL&per_page=1',
+    analyses = list(ghas.github_api_request_paginated(
+        url=f'{api_base}/repos/{org}/{repo}/code-scanning/analyses?tool_name=CodeQL&ref=refs/heads/{access.branch or "main"}&per_page=100',
         secret_factory=secret_factory,
-    )
+    ))
 
-    if analyses is None:
-        logger.warning(f'CodeQL check failed for {repo_url=}')
-        return False, repo_url, settings_url, language
+    active_languages = set()
+    for analysis in analyses:
+        if not isinstance(analysis, dict):
+            continue
+        env = analysis.get('environment', {})
+        if isinstance(env, str):
+            import json as _json
+            try:
+                env = _json.loads(env)
+            except Exception:
+                continue
+        if lang := env.get('language'):
+            active_languages.add(lang.lower())
 
-    codeql_enabled = isinstance(analyses, list) and len(analyses) > 0
-    return codeql_enabled, repo_url, settings_url, language
+    logger.info(f'{repo_url=}: active CodeQL languages={active_languages}')
+    return repo_url, settings_url, active_languages
 
 
 def iter_artefact_metadata(
@@ -140,7 +151,7 @@ def iter_artefact_metadata(
         )
         return
 
-    codeql_enabled, repo_url, settings_url, language = fetch_repo_info(
+    repo_url, settings_url, active_languages = fetch_repo_info(
         source_node=source_node,
         secret_factory=secret_factory,
     )
@@ -148,24 +159,49 @@ def iter_artefact_metadata(
     if not repo_url:
         return
 
-    if codeql_config.languages and language not in codeql_config.languages:
-        logger.info(
-            f'skipping CodeQL check for {repo_url=}: {language=} not in configured {codeql_config.languages=}',
-        )
+    languages_to_check = [l.lower() for l in codeql_config.languages] if codeql_config.languages else None
+
+    if languages_to_check is None:
+        if not active_languages:
+            yield _make_finding(
+                artefact=artefact,
+                codeql_finding_config=codeql_finding_config,
+                repo_url=repo_url,
+                settings_url=settings_url,
+                language=None,
+                creation_timestamp=creation_timestamp,
+            )
         return
 
-    if codeql_enabled:
-        return
+    for language in languages_to_check:
+        if language not in active_languages:
+            finding = _make_finding(
+                artefact=artefact,
+                codeql_finding_config=codeql_finding_config,
+                repo_url=repo_url,
+                settings_url=settings_url,
+                language=language,
+                creation_timestamp=creation_timestamp,
+            )
+            if finding:
+                yield finding
 
+
+def _make_finding(
+    artefact: odg.model.ComponentArtefactId,
+    codeql_finding_config: odg.findings.Finding,
+    repo_url: str,
+    settings_url: str | None,
+    language: str | None,
+    creation_timestamp: datetime.datetime,
+) -> odg.model.ArtefactMetadata | None:
     categorisation = odg.findings.categorise_finding(
         finding_cfg=codeql_finding_config,
         finding_property=odg.model.CodeqlStatus.NOT_ENABLED,
     )
-
     if not categorisation:
-        return
-
-    yield odg.model.ArtefactMetadata(
+        return None
+    return odg.model.ArtefactMetadata(
         artefact=artefact,
         meta=odg.model.Metadata(
             datasource=odg.model.Datasource.CODEQL,

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -137,6 +137,9 @@ def iter_artefact_metadata(
         data=odg.model.CodeqlFinding(
             codeql_status=odg.model.CodeqlStatus.NOT_ENABLED,
             severity=categorisation.id,
+            repo_url=source_node.source.access.repoUrl
+            if isinstance(source_node.source.access, ocm.GithubAccess)
+            else None,
         ),
         discovery_date=creation_timestamp.date(),
         allowed_processing_time=categorisation.allowed_processing_time_raw,

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -29,42 +29,67 @@ ci.log.configure_default_logging()
 k8s.logging.configure_kubernetes_logging()
 
 
-def is_codeql_enabled(
+def _parse_github_coords(
+    repo_url: str,
+) -> tuple[str, str, str] | None:
+    parsed = urllib.parse.urlparse(repo_url)
+    path_parts = parsed.path.strip('/').split('/')
+    if len(path_parts) < 2:
+        return None
+    org, repo = path_parts[0], path_parts[1]
+    hostname = parsed.hostname or 'github.com'
+    api_base = (
+        f'https://{hostname}/api/v3' if hostname != 'github.com' else 'https://api.github.com'
+    )
+    return org, repo, api_base
+
+
+def fetch_repo_info(
     source_node: ocm.iter.SourceNode,
     secret_factory: secret_mgmt.SecretFactory,
-) -> bool:
+) -> tuple[bool, str | None, str | None, str | None]:
+    """
+    Returns (codeql_enabled, repo_url, settings_url, language).
+    Makes two GitHub API calls: one to /repos for metadata, one to code-scanning/analyses.
+    """
     access = source_node.source.access
     if not isinstance(access, ocm.GithubAccess):
         logger.info(
             f'source access is not GithubAccess for {source_node.source.name}, skipping CodeQL check',
         )
-        return False
+        return False, None, None, None
 
     repo_url = access.repoUrl
-    parsed = urllib.parse.urlparse(repo_url)
-    path_parts = parsed.path.strip('/').split('/')
-    if len(path_parts) < 2:
+    coords = _parse_github_coords(repo_url)
+    if not coords:
         logger.warning(f'Cannot parse org/repo from {repo_url=}')
-        return False
+        return False, repo_url, None, None
 
-    org, repo = path_parts[0], path_parts[1]
-    hostname = parsed.hostname or 'github.com'
+    org, repo, api_base = coords
 
-    api_base = (
-        f'https://{hostname}/api/v3' if hostname != 'github.com' else 'https://api.github.com'
-    )
-    url = f'{api_base}/repos/{org}/{repo}/code-scanning/analyses?tool_name=CodeQL&per_page=1'
-
-    result, _ = ghas.github_api_request(
-        url=url,
+    repo_info, _ = ghas.github_api_request(
+        url=f'{api_base}/repos/{org}/{repo}',
         secret_factory=secret_factory,
     )
 
-    if result is None:
-        logger.warning(f'CodeQL check failed for {repo_url=}')
-        return False
+    language = None
+    settings_url = None
+    if isinstance(repo_info, dict):
+        language = repo_info.get('language')
+        html_url = repo_info.get('html_url', repo_url)
+        settings_url = f'{html_url}/settings/security_analysis'
 
-    return isinstance(result, list) and len(result) > 0
+    analyses, _ = ghas.github_api_request(
+        url=f'{api_base}/repos/{org}/{repo}/code-scanning/analyses?tool_name=CodeQL&per_page=1',
+        secret_factory=secret_factory,
+    )
+
+    if analyses is None:
+        logger.warning(f'CodeQL check failed for {repo_url=}')
+        return False, repo_url, settings_url, language
+
+    codeql_enabled = isinstance(analyses, list) and len(analyses) > 0
+    return codeql_enabled, repo_url, settings_url, language
 
 
 def iter_artefact_metadata(
@@ -115,7 +140,15 @@ def iter_artefact_metadata(
         )
         return
 
-    if is_codeql_enabled(source_node=source_node, secret_factory=secret_factory):
+    codeql_enabled, repo_url, settings_url, language = fetch_repo_info(
+        source_node=source_node,
+        secret_factory=secret_factory,
+    )
+
+    if codeql_enabled:
+        return
+
+    if not repo_url:
         return
 
     categorisation = odg.findings.categorise_finding(
@@ -137,9 +170,9 @@ def iter_artefact_metadata(
         data=odg.model.CodeqlFinding(
             codeql_status=odg.model.CodeqlStatus.NOT_ENABLED,
             severity=categorisation.id,
-            repo_url=source_node.source.access.repoUrl
-            if isinstance(source_node.source.access, ocm.GithubAccess)
-            else None,
+            repo_url=repo_url,
+            settings_url=settings_url,
+            language=language,
         ),
         discovery_date=creation_timestamp.date(),
         allowed_processing_time=categorisation.allowed_processing_time_raw,

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -87,11 +87,13 @@ def fetch_repo_info(
         logger.warning(f'Failed to fetch repository languages for {repo_url=}, skipping')
         return repo_url, set(), set(), False
 
-    repo_languages = (
-        {lang.lower() for lang in languages_raw}
-        if isinstance(languages_raw, dict)
-        else set()
-    )
+    if not isinstance(languages_raw, dict):
+        logger.warning(
+            f'Unexpected response type from /languages endpoint for {repo_url=}, skipping',
+        )
+        return repo_url, set(), set(), False
+
+    repo_languages = {lang.lower() for lang in languages_raw}
 
     repo_info, _ = github_util.github_api_request(
         url=f'{api_base}/repos/{org}/{repo}',

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+import collections.abc
+import datetime
+import functools
+import logging
+import urllib.parse
+
+import ci.log
+import cnudie.retrieve
+import ocm
+import ocm.iter
+
+import ctx_util
+import ghas
+import k8s.util
+import k8s.logging
+import odg.extensions_cfg
+import odg.findings
+import odg.labels
+import odg.model
+import odg.util
+import odg_client
+import paths
+import secret_mgmt
+
+
+logger = logging.getLogger(__name__)
+ci.log.configure_default_logging()
+k8s.logging.configure_kubernetes_logging()
+
+
+def is_codeql_enabled(
+    source_node: ocm.iter.SourceNode,
+    secret_factory: secret_mgmt.SecretFactory,
+) -> bool:
+    access = source_node.source.access
+    if not isinstance(access, ocm.GithubAccess):
+        logger.info(
+            f'source access is not GithubAccess for {source_node.source.name}, skipping CodeQL check',
+        )
+        return False
+
+    repo_url = access.repoUrl
+    parsed = urllib.parse.urlparse(repo_url)
+    path_parts = parsed.path.strip('/').split('/')
+    if len(path_parts) < 2:
+        logger.warning(f'Cannot parse org/repo from {repo_url=}')
+        return False
+
+    org, repo = path_parts[0], path_parts[1]
+    hostname = parsed.hostname or 'github.com'
+
+    api_base = (
+        f'https://{hostname}/api/v3' if hostname != 'github.com' else 'https://api.github.com'
+    )
+    url = f'{api_base}/repos/{org}/{repo}/code-scanning/analyses?tool_name=CodeQL&per_page=1'
+
+    result, _ = ghas.github_api_request(
+        url=url,
+        secret_factory=secret_factory,
+    )
+
+    if result is None:
+        logger.warning(f'CodeQL check failed for {repo_url=}')
+        return False
+
+    return isinstance(result, list) and len(result) > 0
+
+
+def iter_artefact_metadata(
+    artefact: odg.model.ComponentArtefactId,
+    component_descriptor_lookup: cnudie.retrieve.ComponentDescriptorLookupById,
+    codeql_finding_config: odg.findings.Finding,
+    codeql_config: odg.extensions_cfg.CodeqlConfig,
+    secret_factory: secret_mgmt.SecretFactory,
+    creation_timestamp: datetime.datetime = datetime.datetime.now(datetime.timezone.utc),
+) -> collections.abc.Generator[odg.model.ArtefactMetadata, None, None]:
+    if not codeql_finding_config.matches(artefact):
+        logger.info(f'CodeQL findings are filtered out for {artefact=}, skipping...')
+        return
+
+    if not codeql_config.is_supported(artefact_kind=artefact.artefact_kind):
+        if codeql_config.on_unsupported is odg.extensions_cfg.WarningVerbosities.FAIL:
+            raise TypeError(
+                f'{artefact.artefact_kind} is not supported by the CodeQL extension, maybe the '
+                'filter configurations have to be adjusted to filter out this artefact kind',
+            )
+        return
+
+    source_node = k8s.util.get_ocm_node(
+        component_descriptor_lookup=component_descriptor_lookup,
+        artefact=artefact,
+        absent_ok=True,
+    )
+
+    if not source_node:
+        logger.info(f'did not find source node for {artefact=}, skipping...')
+        return
+
+    yield odg.model.ArtefactMetadata(
+        artefact=artefact,
+        meta=odg.model.Metadata(
+            datasource=odg.model.Datasource.CODEQL,
+            type=odg.model.Datatype.ARTEFACT_SCAN_INFO,
+            creation_date=creation_timestamp,
+            last_update=creation_timestamp,
+        ),
+        data={},
+        discovery_date=creation_timestamp.date(),
+    )
+
+    if odg.labels.ScanPolicy.SKIP is _find_scan_policy(source_node):
+        logger.info(
+            f'Skip label found for source {source_node.source.name}. CodeQL check skipped.',
+        )
+        return
+
+    if is_codeql_enabled(source_node=source_node, secret_factory=secret_factory):
+        return
+
+    categorisation = odg.findings.categorise_finding(
+        finding_cfg=codeql_finding_config,
+        finding_property=odg.model.CodeqlStatus.NOT_ENABLED,
+    )
+
+    if not categorisation:
+        return
+
+    yield odg.model.ArtefactMetadata(
+        artefact=artefact,
+        meta=odg.model.Metadata(
+            datasource=odg.model.Datasource.CODEQL,
+            type=odg.model.Datatype.CODEQL_FINDING,
+            creation_date=creation_timestamp,
+            last_update=creation_timestamp,
+        ),
+        data=odg.model.CodeqlFinding(
+            codeql_status=odg.model.CodeqlStatus.NOT_ENABLED,
+            severity=categorisation.id,
+        ),
+        discovery_date=creation_timestamp.date(),
+        allowed_processing_time=categorisation.allowed_processing_time_raw,
+    )
+
+
+def _find_scan_policy(
+    snode: ocm.iter.SourceNode,
+) -> odg.labels.ScanPolicy | None:
+    if label := snode.source.find_label(name=odg.labels.SourceScanLabel.name):
+        label_content = odg.labels.deserialise_label(label)
+        return label_content.value.policy
+
+    if label := snode.component.find_label(name=odg.labels.SourceScanLabel.name):
+        label_content = odg.labels.deserialise_label(label)
+        return label_content.value.policy
+
+    return None
+
+
+def scan(
+    artefact: odg.model.ComponentArtefactId,
+    extension_cfg: odg.extensions_cfg.CodeqlConfig,
+    codeql_finding_config: odg.findings.Finding,
+    component_descriptor_lookup: cnudie.retrieve.ComponentDescriptorLookupById,
+    delivery_service_client: odg_client.DeliveryServiceClient,
+    secret_factory: secret_mgmt.SecretFactory,
+    **kwargs,
+):
+    all_metadata = list(
+        iter_artefact_metadata(
+            artefact=artefact,
+            component_descriptor_lookup=component_descriptor_lookup,
+            codeql_finding_config=codeql_finding_config,
+            codeql_config=extension_cfg,
+            secret_factory=secret_factory,
+        ),
+    )
+
+    delivery_service_client.update_metadata(data=all_metadata)
+
+
+def main():
+    parsed_arguments = odg.util.parse_args()
+
+    if not (findings_cfg_path := parsed_arguments.findings_cfg_path):
+        findings_cfg_path = paths.findings_cfg_path()
+
+    codeql_finding_config = odg.findings.Finding.from_file(
+        path=findings_cfg_path,
+        finding_type=odg.model.Datatype.CODEQL_FINDING,
+    )
+
+    if not codeql_finding_config:
+        logger.info('CodeQL findings are disabled, exiting...')
+        return
+
+    secret_factory = ctx_util.secret_factory()
+
+    scan_callback = functools.partial(
+        scan,
+        codeql_finding_config=codeql_finding_config,
+        secret_factory=secret_factory,
+    )
+
+    odg.util.process_backlog_items(
+        parsed_arguments=parsed_arguments,
+        service=odg.extensions_cfg.Services.CODEQL,
+        callback=scan_callback,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/src/codeql.py
+++ b/src/codeql.py
@@ -10,7 +10,7 @@ import cnudie.retrieve
 import ocm
 import ocm.iter
 
-import ghas
+import github_util
 import k8s.util
 import k8s.logging
 import odg.extensions_cfg
@@ -78,7 +78,7 @@ def fetch_repo_info(
         return repo_url, set(), set()
 
     ref = access.ref if access.ref.startswith('refs/') else f'refs/heads/{access.ref}'
-    languages_raw, _ = ghas.github_api_request(
+    languages_raw, _ = github_util.github_api_request(
         url=f'{api_base}/repos/{org}/{repo}/languages',
         secret_factory=secret_factory,
     )
@@ -86,7 +86,7 @@ def fetch_repo_info(
     if isinstance(languages_raw, dict):
         repo_languages = {lang.lower() for lang in languages_raw}
 
-    analyses = list(ghas.github_api_request_paginated(
+    analyses = list(github_util.github_api_request_paginated(
         url=f'{api_base}/repos/{org}/{repo}/code-scanning/analyses?tool_name=CodeQL&ref={ref}&per_page=100',
         secret_factory=secret_factory,
     ))

--- a/src/ghas.py
+++ b/src/ghas.py
@@ -8,10 +8,6 @@ import functools
 import logging
 
 import dacite
-import requests
-import requests.adapters
-import urllib3.util.retry
-
 import ci.log
 import cnudie.retrieve
 import ocm
@@ -28,8 +24,6 @@ import odg.util
 import odg_client
 import paths
 import secret_mgmt
-import secret_mgmt.github
-import util
 
 
 logger = logging.getLogger(__name__)

--- a/src/ghas.py
+++ b/src/ghas.py
@@ -4,7 +4,6 @@ import atexit
 import collections.abc
 import dataclasses
 import datetime
-import functools
 import logging
 
 import dacite
@@ -42,50 +41,6 @@ class SecretAlert:
     url: str | None
 
 
-@functools.cache
-def find_token_for_repo_url(
-    secret_factory: secret_mgmt.SecretFactory,
-    repo_url: str,
-) -> str | None:
-    return github_util.find_token_for_repo_url(
-        secret_factory=secret_factory,
-        repo_url=repo_url,
-    )
-
-
-@functools.cache
-def find_token_for_api_url(
-    secret_factory: secret_mgmt.SecretFactory,
-    api_url: str,
-) -> str | None:
-    return github_util.find_token_for_api_url(
-        secret_factory=secret_factory,
-        api_url=api_url,
-    )
-
-
-def github_api_request(
-    url: str,
-    secret_factory: secret_mgmt.SecretFactory,
-    token: str | None = None,
-) -> tuple[list | dict | None, str | None]:
-    return github_util.github_api_request(
-        url=url,
-        secret_factory=secret_factory,
-        token=token,
-    )
-
-
-def github_api_request_paginated(
-    url: str,
-    secret_factory: secret_mgmt.SecretFactory,
-) -> collections.abc.Iterable[dict]:
-    return github_util.github_api_request_paginated(
-        url=url,
-        secret_factory=secret_factory,
-    )
-
-
 def get_secret_alerts(
     github_hostname: str,
     org: str,
@@ -114,7 +69,7 @@ def get_secret_alerts(
     seen_urls = set()
 
     # default alerts
-    for alert_raw in github_api_request_paginated(
+    for alert_raw in github_util.github_api_request_paginated(
         url=url,
         secret_factory=secret_factory,
     ):
@@ -126,7 +81,7 @@ def get_secret_alerts(
     # generic alerts
     url = f'{url}&secret_type={",".join(secret_types)}'
 
-    for alert_raw in github_api_request_paginated(
+    for alert_raw in github_util.github_api_request_paginated(
         url=url,
         secret_factory=secret_factory,
     ):
@@ -184,7 +139,7 @@ def html_url_for_location(
     if not api_url:
         return None
 
-    result, _ = github_api_request(
+    result, _ = github_util.github_api_request(
         url=api_url,
         secret_factory=secret_factory,
     )
@@ -204,7 +159,7 @@ def iter_secret_locations(
         )
         return
 
-    result, _ = github_api_request(
+    result, _ = github_util.github_api_request(
         url=location_url,
         secret_factory=secret_factory,
     )
@@ -449,7 +404,7 @@ def scan(
         html_url = stale_finding.data.html_url
         api_url = stale_finding.data.url
 
-        stale_alert_data, _ = github_api_request(
+        stale_alert_data, _ = github_util.github_api_request(
             url=api_url,
             secret_factory=secret_factory,
         )

--- a/src/ghas.py
+++ b/src/ghas.py
@@ -23,6 +23,7 @@ import odg.util
 import odg_client
 import paths
 import secret_mgmt
+import util
 
 
 logger = logging.getLogger(__name__)

--- a/src/ghas.py
+++ b/src/ghas.py
@@ -18,6 +18,7 @@ import ocm
 import ocm.util
 
 import ctx_util
+import github_util
 import k8s.logging
 import lookups
 import odg.extensions_cfg
@@ -52,17 +53,10 @@ def find_token_for_repo_url(
     secret_factory: secret_mgmt.SecretFactory,
     repo_url: str,
 ) -> str | None:
-    github_api = secret_mgmt.github.github_api(
+    return github_util.find_token_for_repo_url(
         secret_factory=secret_factory,
         repo_url=repo_url,
-        absent_ok=True,
     )
-
-    if not github_api:
-        logger.error(f'No GitHub token found for {repo_url=}')
-        return None
-
-    return github_api.session.auth.token
 
 
 @functools.cache
@@ -70,19 +64,9 @@ def find_token_for_api_url(
     secret_factory: secret_mgmt.SecretFactory,
     api_url: str,
 ) -> str | None:
-    hostname = util.urlparse(api_url).hostname
-    path_parts = util.urlparse(api_url).path.strip('/').split('/')
-
-    if len(path_parts) < 2:
-        logger.error(f'Cannot determine repo/org from {api_url=}')
-        return None
-
-    org = path_parts[3]
-    repo_url = f'{hostname}/{org}'
-
-    return find_token_for_repo_url(
+    return github_util.find_token_for_api_url(
         secret_factory=secret_factory,
-        repo_url=repo_url,
+        api_url=api_url,
     )
 
 
@@ -91,71 +75,21 @@ def github_api_request(
     secret_factory: secret_mgmt.SecretFactory,
     token: str | None = None,
 ) -> tuple[list | dict | None, str | None]:
-    """
-    Perform a single authenticated GET request to the GitHub API.
-
-    Returns a tuple of (response_body, next_url), where response_body is the
-    parsed JSON (list or dict) and next_url is the URL of the next page taken
-    from the Link header, or None if there are no further pages. Both values
-    are None if the request fails.
-    """
-    if not token:
-        token = find_token_for_api_url(
-            secret_factory=secret_factory,
-            api_url=url,
-        )
-
-    if not token:
-        return None, None
-
-    # setup session with retry configuration
-    session = requests.Session()
-    retries = urllib3.util.retry.Retry(
-        total=5,
-        backoff_factor=1,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=['GET'],
+    return github_util.github_api_request(
+        url=url,
+        secret_factory=secret_factory,
+        token=token,
     )
-    session.mount('https://', requests.adapters.HTTPAdapter(max_retries=retries))
-
-    try:
-        response = session.get(
-            url,
-            headers={
-                'Authorization': f'token {token}',
-                'Accept': 'application/vnd.github+json',
-            },
-            timeout=30,
-        )
-        response.raise_for_status()
-        next_url = response.links.get('next', {}).get('url')
-        return response.json(), next_url
-    except Exception as e:
-        logger.error(f'GitHub API request failed for {url}: {e}')
-        return None, None
 
 
 def github_api_request_paginated(
     url: str,
     secret_factory: secret_mgmt.SecretFactory,
 ) -> collections.abc.Iterable[dict]:
-    next_url = url
-
-    while next_url:
-        # `next_url` might not contain the org-name but only the org-id, hence use default url
-        token = find_token_for_api_url(
-            secret_factory=secret_factory,
-            api_url=url,
-        )
-
-        page_items, next_url = github_api_request(
-            url=next_url,
-            secret_factory=secret_factory,
-            token=token,
-        )
-
-        if page_items:
-            yield from page_items
+    return github_util.github_api_request_paginated(
+        url=url,
+        secret_factory=secret_factory,
+    )
 
 
 def get_secret_alerts(

--- a/src/github_util.py
+++ b/src/github_util.py
@@ -110,15 +110,27 @@ def find_token_for_api_url(
     secret_factory: secret_mgmt.SecretFactory,
     api_url: str,
 ) -> str | None:
-    hostname = util.urlparse(api_url).hostname
-    path_parts = util.urlparse(api_url).path.strip('/').split('/')
+    parsed = util.urlparse(api_url)
+    hostname = parsed.hostname
+    path_parts = parsed.path.strip('/').split('/')
 
     if len(path_parts) < 2:
         logger.error(f'Cannot determine repo/org from {api_url=}')
         return None
 
-    org = path_parts[3]
-    repo_url = f'{hostname}/{org}'
+    # github.com: https://api.github.com/repos/{org}/...  -> path_parts[1]
+    # github enterprise: https://host/api/v3/repos/{org}/... -> path_parts[3]
+    if hostname == 'api.github.com':
+        org_index = 1
+    else:
+        org_index = 3
+
+    if len(path_parts) <= org_index:
+        logger.error(f'Cannot determine org from {api_url=}')
+        return None
+
+    org = path_parts[org_index]
+    repo_url = f'github.com/{org}' if hostname == 'api.github.com' else f'{hostname}/{org}'
 
     return find_token_for_repo_url(
         secret_factory=secret_factory,

--- a/src/github_util.py
+++ b/src/github_util.py
@@ -7,8 +7,14 @@ import time
 import github3
 import github3.issues
 import github3.repos
+import requests
+import requests.adapters
+import urllib3.util.retry
 
 import github.retry
+import secret_mgmt
+import secret_mgmt.github
+import util
 
 
 logger = logging.getLogger(__name__)
@@ -79,3 +85,112 @@ def filter_issues_for_labels(
         return labels.issubset(issue_labels)
 
     return tuple(issue for issue in issues if filter_issue(issue))
+
+
+@functools.cache
+def find_token_for_repo_url(
+    secret_factory: secret_mgmt.SecretFactory,
+    repo_url: str,
+) -> str | None:
+    github_api = secret_mgmt.github.github_api(
+        secret_factory=secret_factory,
+        repo_url=repo_url,
+        absent_ok=True,
+    )
+
+    if not github_api:
+        logger.error(f'No GitHub token found for {repo_url=}')
+        return None
+
+    return github_api.session.auth.token
+
+
+@functools.cache
+def find_token_for_api_url(
+    secret_factory: secret_mgmt.SecretFactory,
+    api_url: str,
+) -> str | None:
+    hostname = util.urlparse(api_url).hostname
+    path_parts = util.urlparse(api_url).path.strip('/').split('/')
+
+    if len(path_parts) < 2:
+        logger.error(f'Cannot determine repo/org from {api_url=}')
+        return None
+
+    org = path_parts[3]
+    repo_url = f'{hostname}/{org}'
+
+    return find_token_for_repo_url(
+        secret_factory=secret_factory,
+        repo_url=repo_url,
+    )
+
+
+def github_api_request(
+    url: str,
+    secret_factory: secret_mgmt.SecretFactory,
+    token: str | None = None,
+) -> tuple[list | dict | None, str | None]:
+    """
+    Perform a single authenticated GET request to the GitHub API.
+
+    Returns a tuple of (response_body, next_url), where response_body is the
+    parsed JSON (list or dict) and next_url is the URL of the next page taken
+    from the Link header, or None if there are no further pages. Both values
+    are None if the request fails.
+    """
+    if not token:
+        token = find_token_for_api_url(
+            secret_factory=secret_factory,
+            api_url=url,
+        )
+
+    if not token:
+        return None, None
+
+    session = requests.Session()
+    retries = urllib3.util.retry.Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=['GET'],
+    )
+    session.mount('https://', requests.adapters.HTTPAdapter(max_retries=retries))
+
+    try:
+        response = session.get(
+            url,
+            headers={
+                'Authorization': f'token {token}',
+                'Accept': 'application/vnd.github+json',
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        next_url = response.links.get('next', {}).get('url')
+        return response.json(), next_url
+    except Exception as e:
+        logger.error(f'GitHub API request failed for {url}: {e}')
+        return None, None
+
+
+def github_api_request_paginated(
+    url: str,
+    secret_factory: secret_mgmt.SecretFactory,
+) -> collections.abc.Iterable[dict]:
+    next_url = url
+
+    while next_url:
+        token = find_token_for_api_url(
+            secret_factory=secret_factory,
+            api_url=url,
+        )
+
+        page_items, next_url = github_api_request(
+            url=next_url,
+            secret_factory=secret_factory,
+            token=token,
+        )
+
+        if page_items:
+            yield from page_items

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -932,8 +932,9 @@ class CodeqlConfig(BacklogItemMixins):
         Defines the handling if a backlog item should be processed which contains unsupported
         properties, e.g. an unsupported artefact kind.
     :param list[str] languages:
-        If non-empty, only repositories whose primary language is in this list will be checked.
-        If empty or omitted, all repositories are checked regardless of language.
+        Languages to check CodeQL coverage for. Must be non-empty; if empty,
+        all artefacts are skipped. A finding is emitted for each language that
+        is present in the repository but not actively scanned by CodeQL.
     """
 
     service: Services = Services.CODEQL

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -956,7 +956,8 @@ class CodeqlConfig(BacklogItemMixins):
         if artefact_kind and artefact_kind not in supported_artefact_kinds:
             if self.on_unsupported is WarningVerbosities.WARNING:
                 logger.warning(
-                    f'{artefact_kind=} is not supported for CodeQL scans, {supported_artefact_kinds=}',
+                    f'{artefact_kind=} is not supported for CodeQL scans, '
+                    f'{supported_artefact_kinds=}',
                 )
             return False
 

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -941,7 +941,7 @@ class CodeqlConfig(BacklogItemMixins):
     delivery_service_url: str
     interval: int = 60 * 60 * 24  # 24h
     on_unsupported: WarningVerbosities = WarningVerbosities.WARNING
-    languages: list[str] = dataclasses.field(default_factory=list)
+    languages: list[str]
 
     def is_supported(
         self,

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -925,10 +925,10 @@ class GHASConfig(ExtensionCfgMixins):
 @dataclasses.dataclass(kw_only=True)
 class CodeqlConfig(BacklogItemMixins):
     """
-    :param str delivery_service_url
+    :param str delivery_service_url:
     :param int interval:
         Time after which an artefact must be re-checked at latest.
-    :param WarningVerbosities on_unsupported
+    :param WarningVerbosities on_unsupported:
         Defines the handling if a backlog item should be processed which contains unsupported
         properties, e.g. an unsupported artefact kind.
     :param list[str] languages:
@@ -953,7 +953,7 @@ class CodeqlConfig(BacklogItemMixins):
         supported_artefact_kinds = (odg.model.ArtefactKind.SOURCE,)
         supported_access_types = (ocm.AccessType.GITHUB,)
 
-        if artefact_kind and artefact_kind not in supported_artefact_kinds:
+        if artefact_kind is not None and artefact_kind not in supported_artefact_kinds:
             if self.on_unsupported is WarningVerbosities.WARNING:
                 logger.warning(
                     f'{artefact_kind=} is not supported for CodeQL scans, '

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -946,13 +946,22 @@ class CodeqlConfig(BacklogItemMixins):
     def is_supported(
         self,
         artefact_kind: odg.model.ArtefactKind | None = None,
+        access: object | None = None,
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.SOURCE,)
+        supported_access_types = (ocm.GithubAccess,)
 
         if artefact_kind and artefact_kind not in supported_artefact_kinds:
             if self.on_unsupported is WarningVerbosities.WARNING:
                 logger.warning(
                     f'{artefact_kind=} is not supported for CodeQL scans, {supported_artefact_kinds=}',
+                )
+            return False
+
+        if access is not None and not isinstance(access, supported_access_types):
+            if self.on_unsupported is WarningVerbosities.WARNING:
+                logger.warning(
+                    f'{type(access)=} is not supported for CodeQL scans, {supported_access_types=}',
                 )
             return False
 

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -948,10 +948,10 @@ class CodeqlConfig(BacklogItemMixins):
     def is_supported(
         self,
         artefact_kind: odg.model.ArtefactKind | None = None,
-        access: object | None = None,
+        access_type: ocm.AccessType | None = None,
     ) -> bool:
         supported_artefact_kinds = (odg.model.ArtefactKind.SOURCE,)
-        supported_access_types = (ocm.GithubAccess,)
+        supported_access_types = (ocm.AccessType.GITHUB,)
 
         if artefact_kind and artefact_kind not in supported_artefact_kinds:
             if self.on_unsupported is WarningVerbosities.WARNING:
@@ -961,10 +961,10 @@ class CodeqlConfig(BacklogItemMixins):
                 )
             return False
 
-        if access is not None and not isinstance(access, supported_access_types):
+        if access_type is not None and access_type not in supported_access_types:
             if self.on_unsupported is WarningVerbosities.WARNING:
                 logger.warning(
-                    f'{type(access)=} is not supported for CodeQL scans, {supported_access_types=}',
+                    f'{access_type=} is not supported for CodeQL scans, {supported_access_types=}',
                 )
             return False
 

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -931,12 +931,16 @@ class CodeqlConfig(BacklogItemMixins):
     :param WarningVerbosities on_unsupported
         Defines the handling if a backlog item should be processed which contains unsupported
         properties, e.g. an unsupported artefact kind.
+    :param list[str] languages:
+        If non-empty, only repositories whose primary language is in this list will be checked.
+        If empty or omitted, all repositories are checked regardless of language.
     """
 
     service: Services = Services.CODEQL
     delivery_service_url: str
     interval: int = 60 * 60 * 24  # 24h
     on_unsupported: WarningVerbosities = WarningVerbosities.WARNING
+    languages: list[str] = dataclasses.field(default_factory=list)
 
     def is_supported(
         self,

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -35,17 +35,17 @@ class Services(enum.StrEnum):
     BDBA = 'bdba'
     CACHE_MANAGER = 'cacheManager'
     CLAMAV = 'clamav'
+    CODEQL = 'codeql'
     CRYPTO = 'crypto'
     DELIVERY_DB_BACKUP = 'deliveryDbBackup'
     FINDINGS_REPORT = 'findingsReport'
     GHAS = 'ghas'
-    CODEQL = 'codeql'
     ISSUE_REPLICATOR = 'issueReplicator'
+    ODG_OPERATOR = 'odg-operator'
     OSID = 'osid'
     PPMS = 'ppms'
     RESPONSIBLES = 'responsibles'
     SAST = 'sast'
-    ODG_OPERATOR = 'odg-operator'
     SBOM_GENERATOR = 'sbomGenerator'
     SLA_VIOLATION_PROFILER = 'slaViolationProfiler'
 
@@ -1320,11 +1320,11 @@ class ExtensionsConfiguration:
     blackduck: BlackDuckConfig | None
     cache_manager: CacheManagerConfig | None
     clamav: ClamAVConfig | None
+    codeql: CodeqlConfig | None
     crypto: CryptoConfig | None
     delivery_db_backup: DeliveryDBBackup | None
     findings_report: FindingsReportConfig | None
     ghas: GHASConfig | None
-    codeql: CodeqlConfig | None
     issue_replicator: IssueReplicatorConfig | None
     odg_operator: OdgOperatorConfig | None
     osid: OsId | None

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -932,9 +932,11 @@ class CodeqlConfig(BacklogItemMixins):
         Defines the handling if a backlog item should be processed which contains unsupported
         properties, e.g. an unsupported artefact kind.
     :param list[str] languages:
-        Languages to check CodeQL coverage for. Must be non-empty; if empty,
-        all artefacts are skipped. A finding is emitted for each language that
-        is present in the repository but not actively scanned by CodeQL.
+        Languages to check CodeQL coverage for, using GitHub repository language names
+        (e.g. 'go', 'python', 'javascript'). The extension automatically handles
+        CodeQL-specific identifiers (e.g. 'javascript-typescript' is treated as
+        covering 'javascript' and 'typescript'). A finding is emitted for each
+        configured language that is present in the repository but not actively scanned.
     """
 
     service: Services = Services.CODEQL

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -39,6 +39,7 @@ class Services(enum.StrEnum):
     DELIVERY_DB_BACKUP = 'deliveryDbBackup'
     FINDINGS_REPORT = 'findingsReport'
     GHAS = 'ghas'
+    CODEQL = 'codeql'
     ISSUE_REPLICATOR = 'issueReplicator'
     OSID = 'osid'
     PPMS = 'ppms'
@@ -921,6 +922,38 @@ class GHASConfig(ExtensionCfgMixins):
         return True
 
 
+@dataclasses.dataclass(kw_only=True)
+class CodeqlConfig(BacklogItemMixins):
+    """
+    :param str delivery_service_url
+    :param int interval:
+        Time after which an artefact must be re-checked at latest.
+    :param WarningVerbosities on_unsupported
+        Defines the handling if a backlog item should be processed which contains unsupported
+        properties, e.g. an unsupported artefact kind.
+    """
+
+    service: Services = Services.CODEQL
+    delivery_service_url: str
+    interval: int = 60 * 60 * 24  # 24h
+    on_unsupported: WarningVerbosities = WarningVerbosities.WARNING
+
+    def is_supported(
+        self,
+        artefact_kind: odg.model.ArtefactKind | None = None,
+    ) -> bool:
+        supported_artefact_kinds = (odg.model.ArtefactKind.SOURCE,)
+
+        if artefact_kind and artefact_kind not in supported_artefact_kinds:
+            if self.on_unsupported is WarningVerbosities.WARNING:
+                logger.warning(
+                    f'{artefact_kind=} is not supported for CodeQL scans, {supported_artefact_kinds=}',
+                )
+            return False
+
+        return True
+
+
 @dataclasses.dataclass
 class ExtensionDefinitionOcmReference:
     component_name: str
@@ -1287,6 +1320,7 @@ class ExtensionsConfiguration:
     delivery_db_backup: DeliveryDBBackup | None
     findings_report: FindingsReportConfig | None
     ghas: GHASConfig | None
+    codeql: CodeqlConfig | None
     issue_replicator: IssueReplicatorConfig | None
     odg_operator: OdgOperatorConfig | None
     osid: OsId | None

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -932,18 +932,19 @@ class CodeqlConfig(BacklogItemMixins):
         Defines the handling if a backlog item should be processed which contains unsupported
         properties, e.g. an unsupported artefact kind.
     :param list[str] languages:
-        Languages to check CodeQL coverage for, using GitHub repository language names
-        (e.g. 'go', 'python', 'javascript'). The extension automatically handles
-        CodeQL-specific identifiers (e.g. 'javascript-typescript' is treated as
-        covering 'javascript' and 'typescript'). A finding is emitted for each
-        configured language that is present in the repository but not actively scanned.
+        Languages to exclude from CodeQL coverage checks, using GitHub repository language names
+        (e.g. 'yaml', 'dockerfile'). If empty (default), findings are created for every language
+        present in the repository that is not actively scanned by CodeQL. If non-empty, the listed
+        languages are skipped and no finding is created for them regardless of CodeQL status.
+        The extension automatically handles CodeQL-specific identifiers (e.g. 'javascript-typescript'
+        covers both 'javascript' and 'typescript').
     """
 
     service: Services = Services.CODEQL
     delivery_service_url: str
     interval: int = 60 * 60 * 24  # 24h
     on_unsupported: WarningVerbosities = WarningVerbosities.WARNING
-    languages: list[str]
+    languages: list[str] = dataclasses.field(default_factory=list)
 
     def is_supported(
         self,

--- a/src/odg/extensions_cfg.yaml
+++ b/src/odg/extensions_cfg.yaml
@@ -75,7 +75,7 @@ ghas:
 
 codeql:
   enabled: False
-  # languages: [Go, Python, Java, JavaScript, TypeScript, C, C++, C#, Kotlin, Ruby, Swift]
+  languages: []  # required, e.g. [go, python, javascript-typescript]
 
 issue_replicator:
   enabled: False

--- a/src/odg/extensions_cfg.yaml
+++ b/src/odg/extensions_cfg.yaml
@@ -75,6 +75,7 @@ ghas:
 
 codeql:
   enabled: False
+  # languages: [Go, Python, Java, JavaScript, TypeScript, C, C++, C#, Kotlin, Ruby, Swift]
 
 issue_replicator:
   enabled: False

--- a/src/odg/extensions_cfg.yaml
+++ b/src/odg/extensions_cfg.yaml
@@ -75,7 +75,7 @@ ghas:
 
 codeql:
   enabled: False
-  languages: []  # required, e.g. [go, python, javascript-typescript]
+  languages: []  # optional list of languages to exclude from checks, e.g. [yaml, dockerfile]
 
 issue_replicator:
   enabled: False

--- a/src/odg/extensions_cfg.yaml
+++ b/src/odg/extensions_cfg.yaml
@@ -73,6 +73,9 @@ findings_report:
 ghas:
   enabled: False
 
+codeql:
+  enabled: False
+
 issue_replicator:
   enabled: False
   mappings:

--- a/src/odg/findings.py
+++ b/src/odg/findings.py
@@ -93,6 +93,15 @@ class SASTFindingSelector:
 
 
 @dataclasses.dataclass
+class CodeqlFindingSelector:
+    """
+    :param list[str] codeql_status:
+        List of regexes to determine matching CodeQL status values.
+    """
+
+    codeql_status: list[str]
+
+@dataclasses.dataclass
 class VulnerabilityFindingSelector:
     """
     :param MinMaxRange cve_score_range:
@@ -146,7 +155,8 @@ class FindingCategorisation:
     allowed_processing_time: MetaAllowedProcessingTimes | str | int | None
     rescoring: RescoringModes | list[RescoringModes] | None
     selector: (
-        CryptoFindingSelector
+        CodeqlFindingSelector
+        | CryptoFindingSelector
         | GHASFindingSelector
         | IPFindingSelector
         | LicenseFindingSelector
@@ -893,6 +903,11 @@ def categorise_finding(
         elif isinstance(selector, SASTFindingSelector):
             for selector_sub_type in selector.sub_types:
                 if re.fullmatch(selector_sub_type, finding_property, re.IGNORECASE):
+                    return categorisation
+
+        elif isinstance(selector, CodeqlFindingSelector):
+            for selector_codeql_status in selector.codeql_status:
+                if re.fullmatch(selector_codeql_status, finding_property, re.IGNORECASE):
                     return categorisation
 
         elif isinstance(selector, VulnerabilityFindingSelector):

--- a/src/odg/findings.py
+++ b/src/odg/findings.py
@@ -530,6 +530,8 @@ class Finding:
 
     def _validate(self):
         match self.type:
+            case odg.model.Datatype.CODEQL_FINDING:
+                self._validate_codeql()
             case odg.model.Datatype.OSID_FINDING:
                 self._validate_osid()
             case odg.model.Datatype.CRYPTO_FINDING:
@@ -561,6 +563,18 @@ class Finding:
         if not violations:
             return
         e = ModelValidationError('osid finding model violations found:')
+        e.add_note('\n'.join(violations))
+        raise e
+
+    def _validate_codeql(self):
+        violations = self._validate_categorisations(
+            expected_selector=CodeqlFindingSelector,
+        )
+
+        if not violations:
+            return
+
+        e = ModelValidationError('codeql finding model violations found:')
         e.add_note('\n'.join(violations))
         raise e
 

--- a/src/odg/findings.py
+++ b/src/odg/findings.py
@@ -101,6 +101,7 @@ class CodeqlFindingSelector:
 
     codeql_status: list[str]
 
+
 @dataclasses.dataclass
 class VulnerabilityFindingSelector:
     """

--- a/src/odg/findings_cfg.yaml
+++ b/src/odg/findings_cfg.yaml
@@ -53,13 +53,13 @@
   issues:
     enable_issues: False
   categorisations:
-    - id: NONE
-      display_name: NONE
+    - id: accepted
+      display_name: Accepted
       value: 0
       rescoring: manual
       allowed_processing_time: ~
-    - id: BLOCKER
-      display_name: BLOCKER
+    - id: not-enabled
+      display_name: Not Enabled
       value: 16
       allowed_processing_time: 0
       rescoring: [manual, automatic]

--- a/src/odg/findings_cfg.yaml
+++ b/src/odg/findings_cfg.yaml
@@ -52,14 +52,6 @@
       artefact_kind: source
   issues:
     enable_issues: False
-  rescoring_ruleset:
-    name: codeql-rescoring-v1
-    rules:
-      - name: codeql-is-optional-for-external-components
-        match:
-          - component_name: github.com/.*
-        codeql_status: not-enabled
-        operation: set-to-NONE
   categorisations:
     - id: NONE
       display_name: NONE

--- a/src/odg/findings_cfg.yaml
+++ b/src/odg/findings_cfg.yaml
@@ -46,6 +46,35 @@
         malware_names:
           - .*
 
+- type: finding/codeql
+  filter:
+    - semantics: include
+      artefact_kind: source
+  issues:
+    enable_issues: False
+  rescoring_ruleset:
+    name: codeql-rescoring-v1
+    rules:
+      - name: codeql-is-optional-for-external-components
+        match:
+          - component_name: github.com/.*
+        codeql_status: not-enabled
+        operation: set-to-NONE
+  categorisations:
+    - id: NONE
+      display_name: NONE
+      value: 0
+      rescoring: manual
+      allowed_processing_time: ~
+    - id: BLOCKER
+      display_name: BLOCKER
+      value: 16
+      allowed_processing_time: 0
+      rescoring: [manual, automatic]
+      selector:
+        codeql_status:
+          - .*
+
 - type: finding/sast
   issues:
     enable_issues: False

--- a/src/odg/model.py
+++ b/src/odg/model.py
@@ -617,10 +617,12 @@ class CodeqlStatus(enum.StrEnum):
 class CodeqlFinding(Finding):
     codeql_status: CodeqlStatus
     repo_url: str | None = None
+    settings_url: str | None = None
+    language: str | None = None
 
     @property
     def key(self) -> str:
-        return _as_key(self.codeql_status)
+        return _as_key(self.codeql_status, self.repo_url)
 
 
 @dataclasses.dataclass

--- a/src/odg/model.py
+++ b/src/odg/model.py
@@ -42,6 +42,7 @@ class Datatype(enum.StrEnum):
     DIKI_FINDING = 'finding/diki'
     FALCO_FINDING = 'finding/falco'
     KYVERNO_FINDING = 'finding/kyverno'
+    CODEQL_FINDING = 'finding/codeql'
     GHAS_FINDING = 'finding/ghas'
     INVENTORY_FINDING = 'finding/inventory'
     IP_FINDING = 'finding/ip'
@@ -62,6 +63,7 @@ class Datatype(enum.StrEnum):
             Datatype.DIKI_FINDING: Datasource.DIKI,
             Datatype.FALCO_FINDING: Datasource.FALCO,
             Datatype.KYVERNO_FINDING: Datasource.KYVERNO,
+            Datatype.CODEQL_FINDING: Datasource.CODEQL,
             Datatype.GHAS_FINDING: Datasource.GHAS,
             Datatype.INVENTORY_FINDING: Datasource.INVENTORY,
             Datatype.IP_FINDING: Datasource.BLACKDUCK,
@@ -81,6 +83,7 @@ class Datasource(enum.StrEnum):
     BDBA = 'bdba'
     BLACKDUCK = 'blackduck'
     CLAMAV = 'clamav'
+    CODEQL = 'codeql'
     CRYPTO = 'crypto'
     DELIVERY_DASHBOARD = 'delivery-dashboard'
     DIKI = 'diki'
@@ -104,6 +107,7 @@ class Datasource(enum.StrEnum):
                 Datatype.VULNERABILITY_FINDING,
             ),
             Datasource.CLAMAV: (Datatype.MALWARE_FINDING,),
+            Datasource.CODEQL: (Datatype.CODEQL_FINDING,),
             Datasource.CRYPTO: (
                 Datatype.CRYPTO_FINDING,
                 Datatype.CRYPTO_ASSET,
@@ -605,6 +609,28 @@ class RescoreSastFinding:
         return _as_key(self.sast_status, self.sub_type)
 
 
+class CodeqlStatus(enum.StrEnum):
+    NOT_ENABLED = 'not-enabled'
+
+
+@dataclasses.dataclass
+class CodeqlFinding(Finding):
+    codeql_status: CodeqlStatus
+
+    @property
+    def key(self) -> str:
+        return _as_key(self.codeql_status)
+
+
+@dataclasses.dataclass
+class RescoreCodeqlFinding:
+    codeql_status: CodeqlStatus
+
+    @property
+    def key(self) -> str:
+        return _as_key(self.codeql_status)
+
+
 @dataclasses.dataclass
 class OsIdFinding(Finding):
     osid: OperatingSystemId
@@ -937,6 +963,7 @@ class CustomRescoring:
         | RescoringLicenseFinding
         | MalwareFindingDetails
         | RescoreSastFinding
+        | RescoreCodeqlFinding
         | RescoringCryptoFinding
         | RescoringDikiFinding
         | RescoreOsIdFinding
@@ -973,6 +1000,7 @@ class SlaViolation:
         | RescoringLicenseFinding
         | MalwareFindingDetails
         | RescoreSastFinding
+        | RescoreCodeqlFinding
         | RescoringCryptoFinding
         | RescoringDikiFinding
         | RescoreOsIdFinding
@@ -1647,6 +1675,7 @@ class ArtefactMetadataSpecificity(enum.Enum):
 
 FindingModels = (
     ClamAVMalwareFinding
+    | CodeqlFinding
     | CryptoFinding
     | DikiFinding
     | FalcoFinding

--- a/src/odg/model.py
+++ b/src/odg/model.py
@@ -616,9 +616,8 @@ class CodeqlStatus(enum.StrEnum):
 @dataclasses.dataclass
 class CodeqlFinding(Finding):
     codeql_status: CodeqlStatus
-    repo_url: str | None = None
-    settings_url: str | None = None
-    language: str | None = None
+    repo_url: str
+    language: str
 
     @property
     def key(self) -> str:
@@ -628,10 +627,12 @@ class CodeqlFinding(Finding):
 @dataclasses.dataclass
 class RescoreCodeqlFinding:
     codeql_status: CodeqlStatus
+    repo_url: str
+    language: str
 
     @property
     def key(self) -> str:
-        return _as_key(self.codeql_status)
+        return _as_key(self.codeql_status, self.repo_url, self.language)
 
 
 @dataclasses.dataclass

--- a/src/odg/model.py
+++ b/src/odg/model.py
@@ -622,7 +622,7 @@ class CodeqlFinding(Finding):
 
     @property
     def key(self) -> str:
-        return _as_key(self.codeql_status, self.repo_url)
+        return _as_key(self.codeql_status, self.repo_url, self.language)
 
 
 @dataclasses.dataclass

--- a/src/odg/model.py
+++ b/src/odg/model.py
@@ -616,6 +616,7 @@ class CodeqlStatus(enum.StrEnum):
 @dataclasses.dataclass
 class CodeqlFinding(Finding):
     codeql_status: CodeqlStatus
+    repo_url: str | None = None
 
     @property
     def key(self) -> str:

--- a/src/odg/model.py
+++ b/src/odg/model.py
@@ -38,14 +38,14 @@ class Datatype(enum.StrEnum):
     SLA_VIOLATION = 'sla_violation'
 
     # finding types
+    CODEQL_FINDING = 'finding/codeql'
     CRYPTO_FINDING = 'finding/crypto'
     DIKI_FINDING = 'finding/diki'
     FALCO_FINDING = 'finding/falco'
-    KYVERNO_FINDING = 'finding/kyverno'
-    CODEQL_FINDING = 'finding/codeql'
     GHAS_FINDING = 'finding/ghas'
     INVENTORY_FINDING = 'finding/inventory'
     IP_FINDING = 'finding/ip'
+    KYVERNO_FINDING = 'finding/kyverno'
     LICENSE_FINDING = 'finding/license'
     MALWARE_FINDING = 'finding/malware'
     OSID_FINDING = 'finding/osid'
@@ -59,14 +59,14 @@ class Datatype(enum.StrEnum):
 
     def datasource(self) -> 'Datasource':
         return {
+            Datatype.CODEQL_FINDING: Datasource.CODEQL,
             Datatype.CRYPTO_FINDING: Datasource.CRYPTO,
             Datatype.DIKI_FINDING: Datasource.DIKI,
             Datatype.FALCO_FINDING: Datasource.FALCO,
-            Datatype.KYVERNO_FINDING: Datasource.KYVERNO,
-            Datatype.CODEQL_FINDING: Datasource.CODEQL,
             Datatype.GHAS_FINDING: Datasource.GHAS,
             Datatype.INVENTORY_FINDING: Datasource.INVENTORY,
             Datatype.IP_FINDING: Datasource.BLACKDUCK,
+            Datatype.KYVERNO_FINDING: Datasource.KYVERNO,
             Datatype.LICENSE_FINDING: Datasource.BDBA,
             Datatype.MALWARE_FINDING: Datasource.CLAMAV,
             Datatype.OSID_FINDING: Datasource.OSID,

--- a/src/odg/profiles.yaml
+++ b/src/odg/profiles.yaml
@@ -1,5 +1,6 @@
 - name: default
   finding_types:
+    - finding/codeql
     - finding/crypto
     - finding/diki
     - finding/falco

--- a/src/sast.py
+++ b/src/sast.py
@@ -65,8 +65,10 @@ def create_missing_linter_finding(
     artefact: odg.model.ComponentArtefactId,
     sub_type: odg.model.SastSubType,
     categorisation: odg.findings.FindingCategorisation,
-    creation_timestamp: datetime.datetime = datetime.datetime.now(tz=datetime.timezone.utc),
+    creation_timestamp: datetime.datetime | None = None,
 ) -> odg.model.ArtefactMetadata | None:
+    if creation_timestamp is None:
+        creation_timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
     return odg.model.ArtefactMetadata(
         artefact=artefact,
         meta=odg.model.Metadata(
@@ -89,8 +91,10 @@ def iter_sast_artefacts_for_sub_type(
     sast_finding_config: odg.findings.Finding,
     sub_type: odg.model.SastSubType,
     artefact: odg.model.ComponentArtefactId,
-    creation_timestamp: datetime.datetime = datetime.datetime.now(datetime.timezone.utc),
+    creation_timestamp: datetime.datetime | None = None,
 ) -> collections.abc.Generator[odg.model.ArtefactMetadata, None, None]:
+    if creation_timestamp is None:
+        creation_timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
     categorisation = odg.findings.categorise_finding(
         finding_cfg=sast_finding_config,
         finding_property=sub_type,
@@ -133,12 +137,14 @@ def iter_artefact_metadata(
     component_descriptor_lookup: cnudie.retrieve.ComponentDescriptorLookupById,
     sast_finding_config: odg.findings.Finding,
     sast_config: odg.extensions_cfg.SASTConfig,
-    creation_timestamp: datetime.datetime = datetime.datetime.now(datetime.timezone.utc),
+    creation_timestamp: datetime.datetime | None = None,
 ) -> collections.abc.Generator[odg.model.ArtefactMetadata, None, None]:
     """
     Processes source nodes for a given component descriptor, yielding SAST metadata.
     Handles resource filtering, local linter findings, and rescoring logic.
     """
+    if creation_timestamp is None:
+        creation_timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
     if not sast_finding_config.matches(artefact):
         logger.info(f'SAST findings are filtered out for {artefact=}, skipping...')
         return


### PR DESCRIPTION
## Summary

- Adds a new `codeql` extension that checks whether GitHub Advanced Security CodeQL is enabled for each source artefact referenced by an OCM component
- Implements use case 1 from the CodeQL extension design (enabled/disabled check only — findings processing is out of scope)
- Follows the same pattern as the existing `sast` extension

## Changes

| File | Change |
|------|--------|
| `src/codeql.py` | New extension — queries GitHub code-scanning analyses API (`tool_name=CodeQL`), emits `CodeqlFinding(NOT_ENABLED)` when CodeQL is absent |
| `src/odg/model.py` | Add `Datatype.CODEQL_FINDING`, `Datasource.CODEQL`, `CodeqlStatus`, `CodeqlFinding`, `RescoreCodeqlFinding` |
| `src/odg/extensions_cfg.py` | Add `Services.CODEQL` and `CodeqlConfig` (BacklogItemMixins, same as `SASTConfig`) |
| `src/odg/extensions_cfg.yaml` | Add `codeql: enabled: False` default |
| `src/odg/findings_cfg.yaml` | Add `finding/codeql` block with BLOCKER categorisation; external (`github.com`) components auto-rescored to NONE |
| `src/odg/findings.py` | Add `CodeqlFindingSelector` for `categorise_finding()` matching on `codeql_status` |
| `src/artefact_enumerator.py` | Register `CODEQL` service so backlog items are created for source artefacts |

## Design decisions

- **Separate extension, not a SAST sub-type** — CodeQL is a distinct scanner (GitHub Advanced Security feature), not a missing-linter variant
- **Reuses `ghas.github_api_request()`** — same GitHub API authentication mechanism as the existing GHAS extension
- **`repo_url` stored in finding** — allows direct navigation to the repository from the dashboard/issue view
- **`github.com` components exempt** — external open-source components are not subject to SAP product standards

## Prerequisites for full E2E test

- GitHub App (app_id: 2019 on `github.tools.sap`) needs `security_events: read` permission added
- Deploy to Dev landscape (delivery-service image must include this branch)

## Test plan

- [x] Verify `codeql.py` loads and starts polling backlog items
- [x] Verify `artefact-enumerator` creates `codeql` backlog items for source artefacts
- [x] Verify GitHub API call succeeds once `security_events: read` permission is granted to GitHub App
- [x] Verify `CodeqlFinding(NOT_ENABLED)` is stored in DB for repos without CodeQL
- [x] Verify no finding is stored for repos with CodeQL enabled
- [x] ~Verify `github.com` components are auto-rescored to NONE~ -> out of scope


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```feature operator
Introduced a new extension `codeql` which is capable of creating findings for missing CodeQL scans
```