### PR TITLE
fix(tests): Prevent against undefined script arguments

### DIFF
--- a/.ci/test
+++ b/.ci/test
@@ -9,7 +9,7 @@ if ! which pytest &>/dev/null; then
   exit 1
 fi
 
-if PYTHONPATH="${repo_root}:${PYTHONPATH:-}" pytest "${repo_root}" "${@}"; then
+if PYTHONPATH="${repo_root}:${PYTHONPATH:-}" pytest "${repo_root}" "$@"; then
   echo 'Unittest executions succeeded'
   exit 0
 else


### PR DESCRIPTION
what is happening:
1. set -u makes bash treat undefined variables as errors
2. Line 12 tries to reference "${@}" (all script arguments)
3. When you run bash .ci/test without any arguments, ${@} is empty/unset
4. The -u flag interprets this as an error: "unbound variable"

the fix:
"$@" (without curly braces)

- This is a special case in bash grammar
- When there are no arguments, "$@" expands to nothing at all - not even an empty string
- The entire token disappears from the command
- So pytest "${repo_root}" "$@" becomes just pytest "${repo_root}" when no args are passed

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix developer
Running tests no longer requires to provide empty argument array on bash
```
