### PR TITLE
feat(rescoring): Harmonise and fix rescoring scopes

### DIFF
--- a/src/bdba_utils/util.py
+++ b/src/bdba_utils/util.py
@@ -19,6 +19,7 @@ import odg.cvss
 import odg.findings
 import odg.model
 import odg_client
+import rescore.utility
 
 
 logger = logging.getLogger(__name__)
@@ -73,12 +74,9 @@ def iter_artefact_metadata(
     # rescoring should not reference artefact version so that the `ARTEFACT` rescoring scope will be
     # used -> rescoring will be used for future versions as well, so there is no need to replicate
     # BDBA triages to new BDBA scans
-    rescoring_artefact_ref = dataclasses.replace(
-        finding_artefact_ref,
-        artefact=dataclasses.replace(
-            finding_artefact_ref.artefact,
-            artefact_version=None,
-        ),
+    rescoring_artefact_ref = rescore.utility.scoped_component_artefact_id(
+        component_artefact_id=artefact_ref,
+        scope=odg.model.ArtefactMetadataSpecificity.ARTEFACT,
     )
 
     existing_findings_by_key = {

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -1002,7 +1002,13 @@ class ArtefactMetadataQuery(aiohttp.web.View):
                 yield query
 
             if artefact_ref.artefact_kind:
-                yield dm.ArtefactMetaData.artefact_kind == artefact_ref.artefact_kind
+                yield sa.or_(
+                    sa.and_(
+                        none_ok,
+                        dm.ArtefactMetaData.artefact_kind.is_(None),
+                    ),
+                    dm.ArtefactMetaData.artefact_kind == artefact_ref.artefact_kind,
+                )
 
             if not artefact_ref.artefact:
                 return

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -1041,12 +1041,18 @@ class ArtefactMetadataQuery(aiohttp.web.View):
                 )
 
             if artefact_extra_id := artefact_ref.artefact.normalised_artefact_extra_id:
+                stripped_artefact_extra_id = odg.model.normalise_artefact_extra_id(
+                    artefact_extra_id=artefact_ref.artefact.artefact_extra_id,
+                    omit_version=True,
+                )
+
                 yield sa.or_(
                     sa.and_(
                         none_ok,
                         dm.ArtefactMetaData.artefact_extra_id_normalised == '',
                     ),
                     dm.ArtefactMetaData.artefact_extra_id_normalised == artefact_extra_id,
+                    dm.ArtefactMetaData.artefact_extra_id_normalised == stripped_artefact_extra_id,
                 )
 
         async def artefact_refs_queries(artefact_refs: list[odg.model.ComponentArtefactId]):

--- a/src/odg/model.py
+++ b/src/odg/model.py
@@ -203,13 +203,22 @@ class OsStatus(enum.StrEnum):
 
 def normalise_artefact_extra_id(
     artefact_extra_id: dict[str, str],
+    omit_version: bool = False,
 ) -> str:
     """
     generate stable representation of `artefact_extra_id`
 
     sorted by key in alphabetical order and concatinated following pattern:
     key1:value1_key2:value2_ ...
+
+    If `omit_version` is set, a possible `version` property is removed from the `artefact_extra_id`.
+    This might be used for scoped values which should be specific for a single artefact (e.g. a
+    certain os distribution of an image) but independent of its version.
     """
+    if omit_version and 'version' in artefact_extra_id:
+        artefact_extra_id = artefact_extra_id.copy()
+        del artefact_extra_id['version']
+
     s = sorted(artefact_extra_id.items(), key=lambda items: items[0])
     return '_'.join([':'.join(values) for values in s])
 

--- a/src/rescore/artefacts.py
+++ b/src/rescore/artefacts.py
@@ -117,6 +117,11 @@ async def _find_rescorings(
     artefact: odg.model.ComponentArtefactId,
     type_filter: list[str] = [],
 ) -> list[odg.model.ArtefactMetadata]:
+    stripped_artefact_extra_id = odg.model.normalise_artefact_extra_id(
+        artefact_extra_id=artefact.artefact.artefact_extra_id,
+        omit_version=True,
+    )
+
     db_statement = sa.select(dm.ArtefactMetaData).where(
         sa.and_(
             dm.ArtefactMetaData.type == odg.model.Datatype.RESCORING,
@@ -145,6 +150,7 @@ async def _find_rescorings(
                 dm.ArtefactMetaData.artefact_extra_id_normalised == '',
                 dm.ArtefactMetaData.artefact_extra_id_normalised
                 == artefact.artefact.normalised_artefact_extra_id,
+                dm.ArtefactMetaData.artefact_extra_id_normalised == stripped_artefact_extra_id,
             ),
             sa.or_(
                 dm.ArtefactMetaData.artefact_kind == sa.null(),
@@ -177,6 +183,11 @@ async def _find_scanner_writebacks(
     db_session: sqlasync.session.AsyncSession,
     artefact: odg.model.ComponentArtefactId,
 ) -> list[odg.model.ArtefactMetadata]:
+    stripped_artefact_extra_id = odg.model.normalise_artefact_extra_id(
+        artefact_extra_id=artefact.artefact.artefact_extra_id,
+        omit_version=True,
+    )
+
     db_statement = sa.select(dm.ArtefactMetaData).where(
         sa.and_(
             dm.ArtefactMetaData.type == odg.model.Datatype.SCANNER_WRITEBACK,
@@ -204,6 +215,7 @@ async def _find_scanner_writebacks(
                 dm.ArtefactMetaData.artefact_extra_id_normalised == '',
                 dm.ArtefactMetaData.artefact_extra_id_normalised
                 == artefact.artefact.normalised_artefact_extra_id,
+                dm.ArtefactMetaData.artefact_extra_id_normalised == stripped_artefact_extra_id,
             ),
             sa.or_(
                 dm.ArtefactMetaData.artefact_kind == sa.null(),

--- a/src/rescore/artefacts.py
+++ b/src/rescore/artefacts.py
@@ -146,8 +146,16 @@ async def _find_rescorings(
                 dm.ArtefactMetaData.artefact_extra_id_normalised
                 == artefact.artefact.normalised_artefact_extra_id,
             ),
-            dm.ArtefactMetaData.artefact_kind == artefact.artefact_kind,
-            dm.ArtefactMetaData.artefact_type == artefact.artefact.artefact_type,
+            sa.or_(
+                dm.ArtefactMetaData.artefact_kind == sa.null(),
+                dm.ArtefactMetaData.artefact_kind == '',
+                dm.ArtefactMetaData.artefact_kind == artefact.artefact_kind,
+            ),
+            sa.or_(
+                dm.ArtefactMetaData.artefact_type == sa.null(),
+                dm.ArtefactMetaData.artefact_type == '',
+                dm.ArtefactMetaData.artefact_type == artefact.artefact.artefact_type,
+            ),
         ),
     )
 
@@ -197,8 +205,16 @@ async def _find_scanner_writebacks(
                 dm.ArtefactMetaData.artefact_extra_id_normalised
                 == artefact.artefact.normalised_artefact_extra_id,
             ),
-            dm.ArtefactMetaData.artefact_kind == artefact.artefact_kind,
-            dm.ArtefactMetaData.artefact_type == artefact.artefact.artefact_type,
+            sa.or_(
+                dm.ArtefactMetaData.artefact_kind == sa.null(),
+                dm.ArtefactMetaData.artefact_kind == '',
+                dm.ArtefactMetaData.artefact_kind == artefact.artefact_kind,
+            ),
+            sa.or_(
+                dm.ArtefactMetaData.artefact_type == sa.null(),
+                dm.ArtefactMetaData.artefact_type == '',
+                dm.ArtefactMetaData.artefact_type == artefact.artefact.artefact_type,
+            ),
         ),
     )
 

--- a/src/rescore/utility.py
+++ b/src/rescore/utility.py
@@ -1,4 +1,5 @@
 import collections.abc
+import copy
 import datetime
 import json
 import re
@@ -128,6 +129,61 @@ def rescorings_for_finding_by_specificity(
             reverse=True,
         ),
     )
+
+
+def _scoped_artefact_id(
+    artefact_id: odg.model.LocalArtefactId | None,
+    scope: odg.model.ArtefactMetadataSpecificity,
+) -> odg.model.LocalArtefactId:
+    if not artefact_id:
+        return odg.model.LocalArtefactId()
+
+    artefact_id = copy.deepcopy(artefact_id)
+
+    if scope <= odg.model.ArtefactMetadataSpecificity.GLOBAL:
+        pass
+
+    if scope <= odg.model.ArtefactMetadataSpecificity.COMPONENT:
+        artefact_id.artefact_name = None
+        artefact_id.artefact_type = None
+        artefact_id.artefact_extra_id = {}
+
+    if scope <= odg.model.ArtefactMetadataSpecificity.ARTEFACT:
+        artefact_id.artefact_version = None
+
+        if 'version' in artefact_id.artefact_extra_id:
+            del artefact_id.artefact_extra_id['version']
+
+    if scope <= odg.model.ArtefactMetadataSpecificity.SINGLE:
+        pass
+
+    return artefact_id
+
+
+def scoped_component_artefact_id(
+    component_artefact_id: odg.model.ComponentArtefactId,
+    scope: odg.model.ArtefactMetadataSpecificity,
+) -> odg.model.ComponentArtefactId:
+    component_artefact_id = copy.deepcopy(component_artefact_id)
+
+    if scope <= odg.model.ArtefactMetadataSpecificity.GLOBAL:
+        component_artefact_id.component_name = None
+
+    if scope <= odg.model.ArtefactMetadataSpecificity.COMPONENT:
+        component_artefact_id.artefact_kind = None
+
+    if scope <= odg.model.ArtefactMetadataSpecificity.ARTEFACT:
+        component_artefact_id.component_version = None
+
+    if scope <= odg.model.ArtefactMetadataSpecificity.SINGLE:
+        pass
+
+    component_artefact_id.artefact = _scoped_artefact_id(
+        artefact_id=component_artefact_id.artefact,
+        scope=scope,
+    )
+
+    return component_artefact_id
 
 
 def find_cve_categorisation(

--- a/src/rescore/utility.py
+++ b/src/rescore/utility.py
@@ -24,10 +24,17 @@ def _iter_rescorings_for_finding(
         if rescoring.data.referenced_type != finding.meta.type:
             continue
 
-        if rescoring.artefact.artefact_kind != finding.artefact.artefact_kind:
+        if (
+            rescoring.artefact.artefact_kind
+            and rescoring.artefact.artefact_kind != finding.artefact.artefact_kind
+        ):
             continue
 
-        if rescoring.artefact.artefact.artefact_type != finding.artefact.artefact.artefact_type:
+        if (
+            rescoring.artefact.artefact
+            and rescoring.artefact.artefact.artefact_type
+            and rescoring.artefact.artefact.artefact_type != finding.artefact.artefact.artefact_type
+        ):
             continue
 
         if (
@@ -44,20 +51,23 @@ def _iter_rescorings_for_finding(
             continue
 
         if (
-            rescoring.artefact.artefact.artefact_name
+            rescoring.artefact.artefact
+            and rescoring.artefact.artefact.artefact_name
             and rescoring.artefact.artefact.artefact_name != finding.artefact.artefact.artefact_name
         ):
             continue
 
         if (
-            rescoring.artefact.artefact.artefact_version
+            rescoring.artefact.artefact
+            and rescoring.artefact.artefact.artefact_version
             and rescoring.artefact.artefact.artefact_version
             != finding.artefact.artefact.artefact_version
         ):
             continue
 
         if (
-            rescoring.artefact.artefact.artefact_extra_id
+            rescoring.artefact.artefact
+            and rescoring.artefact.artefact.artefact_extra_id
             and rescoring.artefact.artefact.normalised_artefact_extra_id
             != finding.artefact.artefact.normalised_artefact_extra_id
         ):
@@ -82,6 +92,7 @@ def _iter_rescorings_for_finding(
                 rescoring.data.finding.labels,
             ) != sorted(finding.data.labels):
                 continue
+
         else:
             if rescoring.data.finding.key != finding.data.key:
                 continue

--- a/src/rescore/utility.py
+++ b/src/rescore/utility.py
@@ -95,8 +95,7 @@ def rescorings_for_finding_by_specificity(
 ) -> tuple[odg.model.ArtefactMetadata]:
     """
     Returns all rescorings of `rescorings` which match the given `finding`. If multiple
-    rescorings match the finding, they are ordered based on their specificity (greatest
-    specificity first and if the specificity is the same, the latest rescorings wins).
+    rescorings match the finding, they are ordered based on their creation date.
     """
     rescorings_for_finding = _iter_rescorings_for_finding(
         finding=finding,
@@ -106,10 +105,7 @@ def rescorings_for_finding_by_specificity(
     return tuple(
         sorted(
             rescorings_for_finding,
-            key=lambda rescoring: (
-                rescoring.specificity,
-                util.normalise_date(rescoring.meta.creation_date),
-            ),
+            key=lambda rescoring: util.normalise_date(rescoring.meta.creation_date),
             reverse=True,
         ),
     )

--- a/src/rescore/utility.py
+++ b/src/rescore/utility.py
@@ -20,6 +20,11 @@ def _iter_rescorings_for_finding(
     finding: odg.model.ArtefactMetadata,
     rescorings: collections.abc.Iterable[odg.model.ArtefactMetadata],
 ) -> collections.abc.Generator[odg.model.ArtefactMetadata, None, None]:
+    normalised_finding_extra_identity = odg.model.normalise_artefact_extra_id(
+        artefact_extra_id=finding.artefact.artefact.artefact_extra_id,
+        omit_version=True,
+    )
+
     for rescoring in rescorings:
         if rescoring.data.referenced_type != finding.meta.type:
             continue
@@ -68,8 +73,11 @@ def _iter_rescorings_for_finding(
         if (
             rescoring.artefact.artefact
             and rescoring.artefact.artefact.artefact_extra_id
-            and rescoring.artefact.artefact.normalised_artefact_extra_id
-            != finding.artefact.artefact.normalised_artefact_extra_id
+            and odg.model.normalise_artefact_extra_id(
+                artefact_extra_id=rescoring.artefact.artefact.artefact_extra_id,
+                omit_version=True,
+            )
+            != normalised_finding_extra_identity
         ):
             continue
 

--- a/src/test/test_rescoring.py
+++ b/src/test/test_rescoring.py
@@ -241,3 +241,158 @@ def test_generate_sast_rescorings(
     assert isinstance(rescoring.data, odg.model.CustomRescoring)
     assert rescoring.data.matching_rules == ['central-linting-is-optional-for-external-components']
     assert rescoring.data.severity == 'no-linter-required'
+
+
+@pytest.fixture
+def full_component_artefact_id() -> odg.model.ComponentArtefactId:
+    return odg.model.ComponentArtefactId(
+        component_name='example.org/my-component',
+        component_version='1.2.3',
+        artefact_kind=odg.model.ArtefactKind.RESOURCE,
+        artefact=odg.model.LocalArtefactId(
+            artefact_name='my-artefact',
+            artefact_type='ociImage',
+            artefact_version='1.0.0',
+            artefact_extra_id={
+                'platform': 'linux/amd64',
+                'version': '1.0.0',
+            },
+        ),
+    )
+
+
+def test_scoped_component_artefact_id_single(
+    full_component_artefact_id: odg.model.ComponentArtefactId,
+):
+    result = rescore.utility.scoped_component_artefact_id(
+        component_artefact_id=full_component_artefact_id,
+        scope=odg.model.ArtefactMetadataSpecificity.SINGLE,
+    )
+
+    # SINGLE scope does not clear any fields
+    assert result.component_name == 'example.org/my-component'
+    assert result.component_version == '1.2.3'
+    assert result.artefact_kind == odg.model.ArtefactKind.RESOURCE
+    assert result.artefact.artefact_name == 'my-artefact'
+    assert result.artefact.artefact_type == 'ociImage'
+    assert result.artefact.artefact_version == '1.0.0'
+    assert result.artefact.artefact_extra_id == {
+        'platform': 'linux/amd64',
+        'version': '1.0.0',
+    }
+
+
+def test_scoped_component_artefact_id_artefact(
+    full_component_artefact_id: odg.model.ComponentArtefactId,
+):
+    result = rescore.utility.scoped_component_artefact_id(
+        component_artefact_id=full_component_artefact_id,
+        scope=odg.model.ArtefactMetadataSpecificity.ARTEFACT,
+    )
+
+    # ARTEFACT scope clears component_version and artefact_version + 'version' extra id key
+    assert result.component_name == 'example.org/my-component'
+    assert result.component_version is None
+    assert result.artefact_kind == odg.model.ArtefactKind.RESOURCE
+    assert result.artefact.artefact_name == 'my-artefact'
+    assert result.artefact.artefact_type == 'ociImage'
+    assert result.artefact.artefact_version is None
+    assert 'version' not in result.artefact.artefact_extra_id
+    assert result.artefact.artefact_extra_id == {
+        'platform': 'linux/amd64',
+    }
+
+
+def test_scoped_component_artefact_id_component(
+    full_component_artefact_id: odg.model.ComponentArtefactId,
+):
+    result = rescore.utility.scoped_component_artefact_id(
+        component_artefact_id=full_component_artefact_id,
+        scope=odg.model.ArtefactMetadataSpecificity.COMPONENT,
+    )
+
+    # COMPONENT scope additionally clears artefact_kind and all artefact fields except name
+    assert result.component_name == 'example.org/my-component'
+    assert result.component_version is None
+    assert result.artefact_kind is None
+    assert result.artefact.artefact_name is None
+    assert result.artefact.artefact_type is None
+    assert result.artefact.artefact_version is None
+    assert result.artefact.artefact_extra_id == {}
+
+
+def test_scoped_component_artefact_id_global(
+    full_component_artefact_id: odg.model.ComponentArtefactId,
+):
+    result = rescore.utility.scoped_component_artefact_id(
+        component_artefact_id=full_component_artefact_id,
+        scope=odg.model.ArtefactMetadataSpecificity.GLOBAL,
+    )
+
+    # GLOBAL scope additionally clears component_name
+    assert result.component_name is None
+    assert result.component_version is None
+    assert result.artefact_kind is None
+    assert result.artefact.artefact_name is None
+    assert result.artefact.artefact_type is None
+    assert result.artefact.artefact_version is None
+    assert result.artefact.artefact_extra_id == {}
+
+
+def test_scoped_component_artefact_id_does_not_mutate_input(
+    full_component_artefact_id: odg.model.ComponentArtefactId,
+):
+    original_name = full_component_artefact_id.component_name
+    original_version = full_component_artefact_id.component_version
+    original_extra_id = dict(full_component_artefact_id.artefact.artefact_extra_id)
+
+    rescore.utility.scoped_component_artefact_id(
+        component_artefact_id=full_component_artefact_id,
+        scope=odg.model.ArtefactMetadataSpecificity.GLOBAL,
+    )
+
+    assert full_component_artefact_id.component_name == original_name
+    assert full_component_artefact_id.component_version == original_version
+    assert full_component_artefact_id.artefact.artefact_extra_id == original_extra_id
+
+
+def test_scoped_component_artefact_id_no_artefact():
+    component_artefact_id = odg.model.ComponentArtefactId(
+        component_name='example.org/my-component',
+        component_version='1.2.3',
+        artefact_kind=odg.model.ArtefactKind.RESOURCE,
+        artefact=None,
+    )
+
+    result = rescore.utility.scoped_component_artefact_id(
+        component_artefact_id=component_artefact_id,
+        scope=odg.model.ArtefactMetadataSpecificity.ARTEFACT,
+    )
+
+    assert result.artefact is not None
+    assert result.artefact.artefact_name is None
+    assert result.artefact.artefact_version is None
+
+
+def test_scoped_component_artefact_id_artefact_extra_id_without_version_key():
+    component_artefact_id = odg.model.ComponentArtefactId(
+        component_name='example.org/my-component',
+        component_version='1.2.3',
+        artefact=odg.model.LocalArtefactId(
+            artefact_name='my-artefact',
+            artefact_version='1.0.0',
+            artefact_extra_id={
+                'platform': 'linux/amd64',
+            },
+        ),
+    )
+
+    result = rescore.utility.scoped_component_artefact_id(
+        component_artefact_id=component_artefact_id,
+        scope=odg.model.ArtefactMetadataSpecificity.ARTEFACT,
+    )
+
+    assert result.artefact.artefact_version is None
+    assert result.artefact.artefact_extra_id == {
+        'platform': 'linux/amd64',
+    }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/odg-core/issues/845
Fixes https://github.com/open-component-model/open-delivery-gear/issues/106

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```breaking user
The latest rescoring is now always also the effective one (the specificity is not considered anymore)
```
```breaking user
The `artefact` scope will now restrict the rescoring to the exact artefact (ignoring its version). Previously, it was applied to all artefacts sharing the same name and type.
```
```other developer
An empty artefact kind and/or type is now also supported for the `component` and `global` scopes
```
```fix developer
The `version` property (if present) is now purged from the extra identity in case the `artefact` scope is used
```
```fix developer
Imported BDBA triages are now properly using the `artefact` instead of the `single` scope
```
