### PR TITLE
fix(operator): Enable request timeout after "300s"

### DIFF
--- a/src/backlog_controller.py
+++ b/src/backlog_controller.py
@@ -145,7 +145,7 @@ def main():
                 namespace=namespace,
                 plural=k8s.model.BacklogItemCrd.PLURAL_NAME,
                 resource_version=resource_version,
-                timeout_seconds=0,
+                timeout_seconds=300,
             ):
                 if (type := str(event['type'])) == 'MODIFIED':
                     continue

--- a/src/odg_operator/__main__.py
+++ b/src/odg_operator/__main__.py
@@ -578,7 +578,7 @@ def reconcile(
     group: str = odgm.ODGMeta.group,
     plural: str = odgm.ODGMeta.plural,
     resource_version: str = '',
-):
+) -> str:
     """
     watches for events of ODG custom-resource
     creates, updates and deletes ODG installations using managed-resources
@@ -592,7 +592,7 @@ def reconcile(
         version='v1',
         plural=plural,
         resource_version=resource_version,
-        timeout_seconds=0,
+        timeout_seconds=300,
     ):
         try:
             odg_raw = event['object']
@@ -819,6 +819,8 @@ def reconcile(
             )
             logger.error(e)
 
+    return resource_version
+
 
 def _iter_extension_definitions_from_resource_node(
     resource_node: ocm.iter.ResourceNode,
@@ -988,12 +990,15 @@ if __name__ == '__main__':
     logger.info(f'known extension definitions: {[e.name for e in extension_definitions]}')
     kubernetes_api = k8s.util.kubernetes_api(kubeconfig_path=parsed.kubeconfig)
 
+    resource_version = ''
+
     while True:
-        reconcile(
+        resource_version = reconcile(
             extension_definitions=extension_definitions,
             required_extensions=odg_operator_cfg.required_extension_names,
             cluster_identity=odg_operator_cfg.cluster_identity,
             component_descriptor_lookup=component_descriptor_lookup,
             oci_client=oci_client,
             kubernetes_api=kubernetes_api,
+            resource_version=resource_version,
         )

--- a/src/odg_operator/__main__.py
+++ b/src/odg_operator/__main__.py
@@ -790,20 +790,6 @@ def reconcile(
             else:
                 raise NotImplementedError(f'event type {event["type"]} not implemented')
 
-        except kubernetes.client.rest.ApiException as e:
-            if e.status == http.HTTPStatus.GONE:
-                resource_version = ''
-                logger.info('API resource watching expired, will start new watch')
-            else:
-                raise e
-
-        except urllib3.exceptions.ProtocolError:
-            # this is a known error which has no impact on the functionality, thus rather be
-            # degregated to a warning or even info
-            # [ref](https://github.com/kiwigrid/k8s-sidecar/issues/233#issuecomment-1332358459)
-            resource_version = ''
-            logger.info('API resource watching received protocol error, will start new watch')
-
         except ODGException as e:
             import traceback
 
@@ -993,12 +979,33 @@ if __name__ == '__main__':
     resource_version = ''
 
     while True:
-        resource_version = reconcile(
-            extension_definitions=extension_definitions,
-            required_extensions=odg_operator_cfg.required_extension_names,
-            cluster_identity=odg_operator_cfg.cluster_identity,
-            component_descriptor_lookup=component_descriptor_lookup,
-            oci_client=oci_client,
-            kubernetes_api=kubernetes_api,
-            resource_version=resource_version,
-        )
+        try:
+            resource_version = reconcile(
+                extension_definitions=extension_definitions,
+                required_extensions=odg_operator_cfg.required_extension_names,
+                cluster_identity=odg_operator_cfg.cluster_identity,
+                component_descriptor_lookup=component_descriptor_lookup,
+                oci_client=oci_client,
+                kubernetes_api=kubernetes_api,
+                resource_version=resource_version,
+            )
+
+        except kubernetes.client.rest.ApiException as e:
+            if e.status == http.HTTPStatus.GONE:
+                resource_version = ''
+                logger.info('API resource watching expired, will start new watch')
+            else:
+                raise e
+
+        except urllib3.exceptions.ProtocolError:
+            # this is a known error which has no impact on the functionality, thus rather be
+            # degregated to a warning or even info
+            # [ref](https://github.com/kiwigrid/k8s-sidecar/issues/233#issuecomment-1332358459)
+            resource_version = ''
+            logger.info('API resource watching received protocol error, will start new watch')
+
+        except urllib3.exceptions.MaxRetryError as e:
+            if not isinstance(e.reason, urllib3.exceptions.ProtocolError):
+                raise
+            resource_version = ''
+            logger.info('API resource watching received protocol error, will start new watch')


### PR DESCRIPTION
**What this PR does / why we need it**:
The timeout is necessary to prevent keeping an unnoticed stale connection which blocks further events from being processed. If the idle timeout is reached, the watch stream breaks (without error) and will be re-instantiated by the outer `while True` loop. Already processed events will not be processed again because the last processed `resource_version` is kept.

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/147

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix operator
The backlog-controller and odg-operator now specify a request timeout > 0s to prevent stale connections from blocking incoming events
```
```bugfix developer
The ODG operator now properly handles common Kubernetes API watch related exceptions
```
