### PR TITLE
chore(clamav): Increase `CommandReadTimeout` from `15` to `60` seconds

### DIFF
--- a/src/malware/clamd.conf
+++ b/src/malware/clamd.conf
@@ -10,4 +10,4 @@ MaxFileSize 0
 MaxRecursion 0
 MaxFiles 0
 AlertExceedsMax yes
-CommandReadTimeout 15
+CommandReadTimeout 60


### PR DESCRIPTION
**What this PR does / why we need it**:
To prevent creating malware findings related to the (instrumentation of) the used scanner, increase the timeout to avoid noise from latency issues.

On a related note, also check https://github.com/open-component-model/open-delivery-gear/issues/152 to automatically resolve transiently reported "malware" findings.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator
The `CommandReadTimeout` for ClamAV has been increased from 15 to 60 seconds to reduce the number of scanner related "malware" findings
```
