### PR TITLE
Revert "fix(rescoring): Do not overshadow user rescorings"

### DIFF
--- a/src/bdba_utils/util.py
+++ b/src/bdba_utils/util.py
@@ -52,7 +52,6 @@ def iter_artefact_metadata(
     delivery_service_client: odg_client.DeliveryServiceClient,
     vulnerability_cfg: odg.findings.Finding | None = None,
     license_cfg: odg.findings.Finding | None = None,
-    create_rescorings_for_upstream_re_ratings: bool = False,
 ) -> collections.abc.Generator[odg.model.ArtefactMetadata, None, None]:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     discovery_date = datetime.date.today()
@@ -250,8 +249,7 @@ def iter_artefact_metadata(
                 yield artefact_metadata
 
                 if (
-                    create_rescorings_for_upstream_re_ratings
-                    and (existing_finding := existing_findings_by_key.get(artefact_metadata.key))
+                    (existing_finding := existing_findings_by_key.get(artefact_metadata.key))
                     and existing_finding.data.cvss_v3_score != artefact_metadata.data.cvss_v3_score
                     and existing_finding.data.severity != artefact_metadata.data.severity
                     and existing_finding.allowed_processing_time


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit f389b63b3a07f79c07c18a2da8bde03069c1c02d.

By now, the rescoring specificity is not honoured anymore to determine the effective rescoring, but instead only the timestamp is considered. That means, in case the CVE rating changes upstream, a rescoring of scope "SINGLE" will be created (again), but a user can re-assess it by using an arbitrary rescoring scope. Previously, the user had to choose the "SINGLE" scope as well.

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/106

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy user
In case of an upstream CVE re-rating, an automatic rescoring will be created (again) to make this change tracable
```
