### PR TITLE
[hotfix-0.1350] fix(issues): Clear GitHub issue cache to force re-authentication

### DIFF
--- a/src/issue_replicator/__main__.py
+++ b/src/issue_replicator/__main__.py
@@ -487,9 +487,6 @@ def replicate_issue(
         logger.warning('did not find any sprints, exiting...')
         return
 
-    # cache clear is necessary to prevent creating duplicated issues
-    github_util.all_issues.cache_clear()
-
     mapping = extension_cfg.mapping(artefact.component_name)
     gh_api = odg.extensions_cfg.github_api(mapping.github_repository)
     repo = odg.extensions_cfg.github_repository(mapping.github_repository)
@@ -505,6 +502,10 @@ def replicate_issue(
     )
 
     for finding_cfg in finding_cfgs:
+        # cache clear is necessary to prevent creating duplicated issues and to force
+        # re-authentication
+        github_util.all_issues.cache_clear()
+
         replicate_issue_for_finding_type(
             artefact=artefact,
             finding_cfg=finding_cfg,


### PR DESCRIPTION
**What this PR does / why we need it**:
In case of long running issue updates (>1h) for single artefacts, issues which were fetched once might contain an outdated GitHub token. To prevent this, explicitly clear the cache between handling of different finding types to force re-authentication.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```bugfix operator
Clear GitHub issue cache in between iterations for the same artefact to force re-authentication
```
