### PR TITLE
fix(bdba): Increase request timeout (`121s` -> `301s`)

### DIFF
--- a/src/bdba/client.py
+++ b/src/bdba/client.py
@@ -233,7 +233,7 @@ class BDBAApi:
         try:
             timeout = kwargs.pop('timeout')
         except KeyError:
-            timeout = (4, 121)
+            timeout = (4, 301)
 
         return functools.partial(
             method,


### PR DESCRIPTION
**What this PR does / why we need it**:
With the existing timeout of `121s`, the fetch of scan results for large components (e.g. GardenLinux) regularly fails.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```noteworthy developer
Increased the BDBA request timeout from `121s` to `301s`
```
