### PR TITLE
Add ruff and bandit to dev reqs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,5 @@ numpy
 pytest<9.1 # pin for now due to regression
 pytest-asyncio
 scipy
+ruff
+bandit


### PR DESCRIPTION
**What this PR does / why we need it**:

When installing dev dependencies from `requirements-dev.txt` for dev environment, ruff and bandit are missing