### PR TITLE
add GitHub-publishing fields to SlaViolationProfilerConfig

### DIFF
--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -743,6 +743,55 @@ extensions_cfg:
     # - warning: skip processing and log a warning message (default)
     on_unsupported: warning
 
+  # @param extensions_cfg.sla_violation_profiler cronjob which scans OCM components for SLA
+  # violations and optionally publishes a report to a GitHub repository
+  sla_violation_profiler:
+    # @param extensions_cfg.sla_violation_profiler.enabled allows disabling of extension without
+    # removing its configuration
+    enabled: true
+    # @param extensions_cfg.sla_violation_profiler.delivery_service_url url to access the
+    # delivery-service (cluster internal url is sufficient)
+    # e.g.
+    # delivery_service_url: http://delivery-service.<namespace>.svc.cluster.local:8080
+    delivery_service_url: ""
+    # @param extensions_cfg.sla_violation_profiler.components list of OCM components to scan for
+    # SLA violations
+    components:
+        # @param extensions_cfg.sla_violation_profiler.components[].component_name name of the OCM
+        # component
+        # e.g.
+        # component_name: ocm.software/open-delivery-gear
+      - component_name: ""
+        # @param extensions_cfg.sla_violation_profiler.components[].ocm_repo_url may be used to
+        # overwrite the default lookup via ocm_repo_mappings
+        ocm_repo_url: null
+        # @param extensions_cfg.sla_violation_profiler.components[].version version of the component
+        # to scan. Use "greatest" to always scan the latest version
+        version: greatest
+        # @param extensions_cfg.sla_violation_profiler.components[].max_versions_limit maximum number
+        # of versions to evaluate
+        max_versions_limit: 1
+        # @param extensions_cfg.sla_violation_profiler.components[].time_range time interval used to
+        # retrieve the component versions to evaluate
+        time_range:
+          days_from: -365
+          days_to: 0
+    # @param extensions_cfg.sla_violation_profiler.github_repository name of the GitHub repository
+    # where the SLA violation report should be published as a pull request; if not set the report
+    # is only stored in the delivery-service database (optional)
+    # e.g.
+    # github_repository: github.com/<org-name>/<repository-name>
+    github_repository: null
+    # @param extensions_cfg.sla_violation_profiler.branch the name of the branch to publish the
+    # report to
+    branch: master
+    # @param extensions_cfg.sla_violation_profiler.filename the relative path in the target
+    # repository to the file containing the SLA violation report
+    filename: report.md
+    # @param extensions_cfg.sla_violation_profiler.auto_merge whether or not to automatically merge
+    # the pull request which updates the generated report
+    auto_merge: false
+
   # @param extensions_cfg.sbom_generator worker which generates SBoM documents for OCM artefacts and
   # stores them in ODG database. Downloadable via API or ODG-UI
   sbom_generator:

--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -750,9 +750,11 @@ extensions_cfg:
     # removing its configuration
     enabled: true
     # @param extensions_cfg.sla_violation_profiler.delivery_service_url url to access the
-    # delivery-service (cluster internal url is sufficient)
+    # delivery-service; note: this url will be embedded in the published report, so an externally
+    # accessible url should be used here (a cluster-internal url would not be reachable by readers
+    # of the report)
     # e.g.
-    # delivery_service_url: http://delivery-service.<namespace>.svc.cluster.local:8080
+    # delivery_service_url: https://delivery-service.example.com
     delivery_service_url: ""
     # @param extensions_cfg.sla_violation_profiler.components list of OCM components to scan for
     # SLA violations
@@ -778,18 +780,20 @@ extensions_cfg:
           days_to: 0
     # @param extensions_cfg.sla_violation_profiler.github_repository name of the GitHub repository
     # where the SLA violation report should be published as a pull request; if not set the report
-    # is only stored in the delivery-service database (optional)
+    # is generated as a markdown file inside the pod only and not published anywhere (optional)
     # e.g.
     # github_repository: github.com/<org-name>/<repository-name>
     github_repository: null
     # @param extensions_cfg.sla_violation_profiler.branch the name of the branch to publish the
-    # report to
+    # report to (only relevant if github_repository is set)
     branch: master
     # @param extensions_cfg.sla_violation_profiler.filename the relative path in the target
-    # repository to the file containing the SLA violation report
+    # repository to the file containing the SLA violation report (only relevant if
+    # github_repository is set)
     filename: report.md
     # @param extensions_cfg.sla_violation_profiler.auto_merge whether or not to automatically merge
-    # the pull request which updates the generated report
+    # the pull request which updates the generated report (only relevant if github_repository is
+    # set)
     auto_merge: false
 
   # @param extensions_cfg.sbom_generator worker which generates SBoM documents for OCM artefacts and

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -831,6 +831,10 @@ class SlaViolationProfilerConfig(ExtensionCfgMixins):
     service: Services = Services.SLA_VIOLATION_PROFILER
     delivery_service_url: str
     components: list[Component]
+    github_repository: str | None = None
+    branch: str = 'master'
+    filename: str = 'report.md'
+    auto_merge: bool = False
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/src/odg/extensions_cfg.yaml
+++ b/src/odg/extensions_cfg.yaml
@@ -119,3 +119,4 @@ sla_violation_profiler:
       time_range:
         days_from: -365
         days_to: 0
+  github_repository: my-github-repository # <str> optional

--- a/src/test/test_extensions_cfg.py
+++ b/src/test/test_extensions_cfg.py
@@ -25,3 +25,33 @@ def test_enabled_defaults(extensions_cfg: odg.extensions_cfg.ExtensionsConfigura
     assert extensions_cfg.sast.enabled is True
     assert extensions_cfg.bdba.enabled is False
     assert extensions_cfg.clamav.enabled is True
+
+
+def test_sla_violation_profiler_publish_fields():
+    raw = {
+        'defaults': {'delivery_service_url': 'foo'},
+        'sla_violation_profiler': {
+            'components': [],
+            'github_repository': 'github.com/org/repo',
+            'branch': 'main',
+            'filename': 'sla.md',
+            'auto_merge': True,
+        },
+    }
+    cfg = odg.extensions_cfg.ExtensionsConfiguration.from_dict(raw).sla_violation_profiler
+    assert cfg.github_repository == 'github.com/org/repo'
+    assert cfg.branch == 'main'
+    assert cfg.filename == 'sla.md'
+    assert cfg.auto_merge is True
+
+
+def test_sla_violation_profiler_publish_defaults():
+    raw = {
+        'defaults': {'delivery_service_url': 'foo'},
+        'sla_violation_profiler': {'components': []},
+    }
+    cfg = odg.extensions_cfg.ExtensionsConfiguration.from_dict(raw).sla_violation_profiler
+    assert cfg.github_repository is None
+    assert cfg.branch == 'master'
+    assert cfg.filename == 'report.md'
+    assert cfg.auto_merge is False


### PR DESCRIPTION
**What this PR does / why we need it**:
add GitHub-publishing fields to SlaViolationProfilerConfig to publish new sla_violation_report to github
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator

```
