### PR TITLE
feat(artefact-enumerator): Allow filter rules for backlog item creation

### DIFF
--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -79,6 +79,78 @@ extensions_cfg:
         # @param extensions_cfg.artefact_enumerator.components[].max_versions_limit number of
         # versions that should be tracked
         max_versions_limit: 1
+    # @param extensions_cfg.artefact_enumerator.artefact_filters an optional filter to limit
+    # automatic backlog item creation for certain artefacts in general. If only "include" filters are
+    # configured, all other artefacts will be ignored. If only "exclude" filters are configured, all
+    # other artefacts will be considered. If a combination of "include" and "exclude" filters are
+    # configured, all included artefacts which are not specifically excluded as well will be
+    # considered.
+    # note: all properties, except `artefact_kind` and `artefact_extra_id`, will be compared as
+    # regexes
+    artefact_filters:
+        # @param extensions_cfg.artefact_enumerator.artefact_filters[].name only used for
+        # informational purposes, such as logging
+      - name: null
+        # @param extensions_cfg.artefact_enumerator.artefact_filters[].semantics if only "include"
+        # filters are configured, all other artefacts will be ignored. If only "exclude" filters are
+        # configured, all other artefacts will be considered. If a combination of both is configured,
+        # all included artefacts which are not specifically excluded will be considered
+        # options:
+        # - include
+        # - exclude
+        semantics: ""
+        # @param extensions_cfg.artefact_enumerator.artefact_filters[].component_name regex for the
+        # component name
+        # types:
+        # - null
+        # - string
+        # - list of strings
+        component_name: null
+        # @param extensions_cfg.artefact_enumerator.artefact_filters[].component_version regex for
+        # the component version
+        # types:
+        # - null
+        # - string
+        # - list of strings
+        component_version: null
+        # @param extensions_cfg.artefact_enumerator.artefact_filters[].artefact_kind
+        # options:
+        # - resource
+        # - runtime
+        # - source
+        # types:
+        # - null
+        # - kind
+        # - list of kinds
+        artefact_kind: null
+        # @param extensions_cfg.artefact_enumerator.artefact_filters[].artefact_name regex for the
+        # artefact name
+        # types:
+        # - null
+        # - string
+        # - list of strings
+        artefact_name: null
+        # @param extensions_cfg.artefact_enumerator.artefact_filters[].artefact_version regex for the
+        # artefact version
+        # types:
+        # - null
+        # - string
+        # - list of strings
+        artefact_version: null
+        # @param extensions_cfg.artefact_enumerator.artefact_filters[].artefact_type regex for the
+        # artefact type
+        # types:
+        # - null
+        # - string
+        # - list of strings
+        artefact_type: null
+        # @param extensions_cfg.artefact_enumerator.artefact_filters[].artefact_extra_id explicit match
+        # of the artefact extra id
+        # types:
+        # - null
+        # - objects
+        # - list of objects
+        artefact_extra_id: null
 
   # @param extensions_cfg.backlog_controller controller to scale worker pods upon backlog work-items
   backlog_controller:
@@ -1448,7 +1520,7 @@ findings:
         # - string
         # - list of strings
         artefact_type: null
-        # @param findings[].filter[].artefact_type explicit match of the artefact extra id
+        # @param findings[].filter[].artefact_extra_id explicit match of the artefact extra id
         # types:
         # - null
         # - objects

--- a/charts/bootstrapping/values.documentation.yaml
+++ b/charts/bootstrapping/values.documentation.yaml
@@ -80,13 +80,21 @@ extensions_cfg:
         # versions that should be tracked
         max_versions_limit: 1
     # @param extensions_cfg.artefact_enumerator.artefact_filters an optional filter to limit
-    # automatic backlog item creation for certain artefacts in general. If only "include" filters are
-    # configured, all other artefacts will be ignored. If only "exclude" filters are configured, all
-    # other artefacts will be considered. If a combination of "include" and "exclude" filters are
-    # configured, all included artefacts which are not specifically excluded as well will be
-    # considered.
-    # note: all properties, except `artefact_kind` and `artefact_extra_id`, will be compared as
-    # regexes
+    # automatic backlog item creation for certain artefacts in general
+    # options:
+    # - only "include" filters -> all other artefacts will be ignored
+    # - only "exclude" filters -> all other artefacts will be considered
+    # - both "include" and "exclude" filters together -> included artefacts - excluded artefacts
+    # - no filters -> all artefacts will be considered (default)
+    # note: all properties, except `artefact_kind` and `artefact_extra_id`, will be compared as regexes
+    # example (all artefacts named "odg.*" except those of type "sbom"):
+    # artefact_filters:
+    #   - name: no-sboms
+    #     semantics: exclude
+    #     artefact_type: sbom
+    #   - name: only-artefacts-starting-with-odg
+    #     semantics: include
+    #     artefact_name: odg.*
     artefact_filters:
         # @param extensions_cfg.artefact_enumerator.artefact_filters[].name only used for
         # informational purposes, such as logging
@@ -1463,12 +1471,21 @@ findings:
         selector: null
 
     # @param findings[].filter can be used to stop detection of the specified findings for certain
-    # components/artfacts. If only "include" filters are configured, all other components will be
-    # ignored. If only "exclude" filters are configured, all other components will be considered. If
-    # a combination of "include" and "exclude" filters are configured, all included components which
-    # are not specifically excluded as well will be considered.
-    # note: all properties, except `artefact_kind` and `artefact_extra_id`, will be compared as
-    # regexes
+    # components/artfacts
+    # options:
+    # - only "include" filters -> all other artefacts will be ignored
+    # - only "exclude" filters -> all other artefacts will be considered
+    # - both "include" and "exclude" filters together -> included artefacts - excluded artefacts
+    # - no filters -> all artefacts will be considered (default)
+    # note: all properties, except `artefact_kind` and `artefact_extra_id`, will be compared as regexes
+    # example (all artefacts named "odg.*" except those of type "sbom"):
+    # artefact_filters:
+    #   - name: no-sboms
+    #     semantics: exclude
+    #     artefact_type: sbom
+    #   - name: only-artefacts-starting-with-odg
+    #     semantics: include
+    #     artefact_name: odg.*
     filter:
         # @param findings[].filter[].name only used for informational purposes, such as logging
       - name: null

--- a/src/artefact_enumerator.py
+++ b/src/artefact_enumerator.py
@@ -290,7 +290,9 @@ def _process_compliance_snapshot_of_artefact(
         and extensions_cfg.blackduck.enabled
         and extensions_cfg.blackduck.is_supported(artefact_kind=artefact.artefact_kind)
     ):
-        compliance_snapshot, uncommitted_backlog_item = _create_backlog_item(
+        compliance_snapshot, uncommitted_backlog_item = _create_backlog_item_for_extension(
+            finding_cfgs=finding_cfgs,
+            finding_types=(odg.model.Datatype.IP_FINDING,),
             artefact=artefact,
             compliance_snapshot=compliance_snapshot,
             service=odg.extensions_cfg.Services.BLACKDUCK,

--- a/src/artefact_enumerator.py
+++ b/src/artefact_enumerator.py
@@ -15,6 +15,7 @@ import k8s.runtime_artefacts
 import k8s.util
 import lookups
 import odg.extensions_cfg
+import odg.filter
 import odg.findings
 import odg.model
 import odg.util
@@ -515,12 +516,18 @@ def enumerate_artefacts(
     now = datetime.datetime.now()
     today = datetime.date.today()
 
+    artefact_filter = odg.filter.ComponentArtefactRuleSet(
+        rules=extensions_cfg.artefact_enumerator.artefact_filters,
+    )
+
     ocm_artefacts = set(
-        _iter_ocm_artefacts(
+        artefact
+        for artefact in _iter_ocm_artefacts(
             components=extensions_cfg.artefact_enumerator.components,
             delivery_service_client=delivery_service_client,
             component_descriptor_lookup=component_descriptor_lookup,
-        ),
+        )
+        if artefact_filter.allows(artefact)
     )
     logger.info(f'{len(ocm_artefacts)=}')
 
@@ -530,6 +537,7 @@ def enumerate_artefacts(
             namespace=namespace,
             kubernetes_api=kubernetes_api,
         )
+        if artefact_filter.allows(runtime_artefact.artefact)
     }
     logger.info(f'{len(runtime_artefacts)=}')
 

--- a/src/odg/extensions_cfg.py
+++ b/src/odg/extensions_cfg.py
@@ -221,6 +221,8 @@ class ArtefactEnumeratorConfig(ExtensionCfgMixins):
     :param str delivery_service_url
     :param list[Component] components:
         Components which are classified as "active" and for which compliance snapshots are created.
+    :param list[ComponentArtefactFilter] artefact_filters:
+        An optional filter to limit automatic backlog item creation for certain artefacts in general
     :param int compliance_snapshot_grace_period:
         Time after which inactive compliance snapshots are deleted from the delivery-db. During this
         period, the inactive snapshots are used to possibly close outdated GitHub issues (i.e. the
@@ -233,6 +235,9 @@ class ArtefactEnumeratorConfig(ExtensionCfgMixins):
     service: Services = Services.ARTEFACT_ENUMERATOR
     delivery_service_url: str
     components: list[Component]
+    artefact_filters: list[odg.filter.ComponentArtefactFilter] = dataclasses.field(
+        default_factory=list,
+    )
     compliance_snapshot_grace_period: int = 60 * 60 * 24  # 24h
     schedule: str = '*/5 * * * *'  # every 5 minutes
     successful_jobs_history_limit: int = 1

--- a/src/test/test_extensions_cfg.py
+++ b/src/test/test_extensions_cfg.py
@@ -9,6 +9,22 @@ def extensions_cfg() -> odg.extensions_cfg.ExtensionsConfiguration:
         'defaults': {
             'delivery_service_url': 'foo',
         },
+        'artefact_enumerator': {
+            'components': [],
+            'artefact_filters': [
+                {
+                    'semantics': 'include',
+                    'name': 'only-oci',
+                    'component_name': None,
+                    'component_version': None,
+                    'artefact_kind': None,
+                    'artefact_name': None,
+                    'artefact_version': None,
+                    'artefact_type': 'ociImage',
+                    'artefact_extra_id': None,
+                },
+            ],
+        },
         'sast': {
             'enabled': True,
         },
@@ -43,6 +59,26 @@ def test_sla_violation_profiler_publish_fields():
     assert cfg.branch == 'main'
     assert cfg.filename == 'sla.md'
     assert cfg.auto_merge is True
+
+
+def test_artefact_enumerator_filters_default_empty():
+    raw = {
+        'defaults': {'delivery_service_url': 'foo'},
+        'artefact_enumerator': {'components': []},
+    }
+    cfg = odg.extensions_cfg.ExtensionsConfiguration.from_dict(raw).artefact_enumerator
+    assert cfg.artefact_filters == []
+
+
+def test_artefact_enumerator_filters_parsed_from_dict(
+    extensions_cfg: odg.extensions_cfg.ExtensionsConfiguration,
+):
+    artefact_enumerator_cfg = extensions_cfg.artefact_enumerator
+    assert len(artefact_enumerator_cfg.artefact_filters) == 1
+    filter = artefact_enumerator_cfg.artefact_filters[0]
+    assert filter.semantics == 'include'
+    assert filter.name == 'only-oci'
+    assert filter.artefact_type == ['ociImage']
 
 
 def test_sla_violation_profiler_publish_defaults():

--- a/src/test/test_odg_filter.py
+++ b/src/test/test_odg_filter.py
@@ -1,0 +1,100 @@
+import odg.filter
+import odg.model
+
+
+def _artefact(
+    component_name='github.com/org/comp',
+    artefact_name='my-image',
+    artefact_kind=odg.model.ArtefactKind.RESOURCE,
+    artefact_type='ociImage',
+) -> odg.model.ComponentArtefactId:
+    return odg.model.ComponentArtefactId(
+        component_name=component_name,
+        component_version='1.0.0',
+        artefact_kind=artefact_kind,
+        artefact=odg.model.LocalArtefactId(
+            artefact_name=artefact_name,
+            artefact_version='1.0.0',
+            artefact_type=artefact_type,
+            artefact_extra_id={},
+        ),
+    )
+
+
+def test_artefact_filter_ruleset_empty_allows_all():
+    ruleset = odg.filter.ComponentArtefactRuleSet(rules=[])
+    assert ruleset.allows(_artefact()) is True
+
+
+def test_artefact_filter_ruleset_include_matches():
+    rule = odg.filter.ComponentArtefactFilter(
+        semantics=odg.filter.FilterSemantics.INCLUDE,
+        name=None,
+        component_name=None,
+        component_version=None,
+        artefact_kind=None,
+        artefact_name='my-image',
+        artefact_version=None,
+        artefact_type=None,
+        artefact_extra_id=None,
+    )
+    ruleset = odg.filter.ComponentArtefactRuleSet(rules=[rule])
+    assert ruleset.allows(_artefact(artefact_name='my-image')) is True
+    assert ruleset.allows(_artefact(artefact_name='other-image')) is False
+
+
+def test_artefact_filter_ruleset_exclude_matches():
+    rule = odg.filter.ComponentArtefactFilter(
+        semantics=odg.filter.FilterSemantics.EXCLUDE,
+        name=None,
+        component_name=None,
+        component_version=None,
+        artefact_kind=None,
+        artefact_name='skip-me',
+        artefact_version=None,
+        artefact_type=None,
+        artefact_extra_id=None,
+    )
+    ruleset = odg.filter.ComponentArtefactRuleSet(rules=[rule])
+    assert ruleset.allows(_artefact(artefact_name='keep-me')) is True
+    assert ruleset.allows(_artefact(artefact_name='skip-me')) is False
+
+
+def test_artefact_filter_ruleset_include_and_exclude():
+    include = odg.filter.ComponentArtefactFilter(
+        semantics=odg.filter.FilterSemantics.INCLUDE,
+        name=None,
+        component_name='github.com/org/.*',
+        component_version=None,
+        artefact_kind=None,
+        artefact_name=None,
+        artefact_version=None,
+        artefact_type=None,
+        artefact_extra_id=None,
+    )
+    exclude = odg.filter.ComponentArtefactFilter(
+        semantics=odg.filter.FilterSemantics.EXCLUDE,
+        name=None,
+        component_name=None,
+        component_version=None,
+        artefact_kind=None,
+        artefact_name='skip-me',
+        artefact_version=None,
+        artefact_type=None,
+        artefact_extra_id=None,
+    )
+    ruleset = odg.filter.ComponentArtefactRuleSet(rules=[include, exclude])
+    # included component, not excluded artefact → allowed
+    assert ruleset.allows(_artefact(artefact_name='keep-me')) is True
+    # included component, but excluded artefact → denied
+    assert ruleset.allows(_artefact(artefact_name='skip-me')) is False
+    # component outside include pattern → denied
+    assert (
+        ruleset.allows(
+            _artefact(
+                component_name='github.com/other/comp',
+                artefact_name='keep-me',
+            ),
+        )
+        is False
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of only allowing filters to be specified per finding type, this change also allows configuration of filters on the artefact-enumerator itself, thus allowing to filter out certain artefact(groups) from automatic processing in general.
Useful to limit backlog item creation for extensions which are not limited to a certain finding type (e.g. issue-replicator, responsibles) and hence were not affected by the previous filter options.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       action|breaking|noteworthy|feature|bugfix|fix|improvement|other|documentation
- target_group:   operator|user|developer|dependency
-->
```improvement operator
The artefact-enumerator now allows configuration of central filter rules to prevent automatic backlog item creation for specified artefact(group)s
```
